### PR TITLE
Allow `atom()` property keys

### DIFF
--- a/lib/posthog/client.ex
+++ b/lib/posthog/client.ex
@@ -98,6 +98,8 @@ defmodule Posthog.Client do
   @lib_version Mix.Project.config()[:version]
   @lib_name "posthog-elixir"
 
+  import Posthog.Guard, only: [is_keyword_list: 1]
+
   @doc """
   Adds default headers to the request.
 
@@ -245,6 +247,12 @@ defmodule Posthog.Client do
 
   @doc false
   defp deep_stringify_keys(term) when is_map(term) do
+    term
+    |> Enum.map(fn {k, v} -> {to_string(k), deep_stringify_keys(v)} end)
+    |> Enum.into(%{})
+  end
+
+  defp deep_stringify_keys(term) when is_keyword_list(term) do
     term
     |> Enum.map(fn {k, v} -> {to_string(k), deep_stringify_keys(v)} end)
     |> Enum.into(%{})

--- a/lib/posthog/client.ex
+++ b/lib/posthog/client.ex
@@ -249,6 +249,7 @@ defmodule Posthog.Client do
     |> Enum.map(fn {k, v} -> {to_string(k), deep_stringify_keys(v)} end)
     |> Enum.into(%{})
   end
+
   defp deep_stringify_keys(term) when is_list(term), do: Enum.map(term, &deep_stringify_keys/1)
   defp deep_stringify_keys(term), do: term
 

--- a/lib/posthog/client.ex
+++ b/lib/posthog/client.ex
@@ -100,17 +100,15 @@ defmodule Posthog.Client do
 
   import Posthog.Guard, only: [is_keyword_list: 1]
 
-  @doc """
-  Adds default headers to the request.
-
-  ## Parameters
-
-    * `additional_headers` - List of additional headers to include
-
-  ## Examples
-
-      headers([{"x-forwarded-for", "127.0.0.1"}])
-  """
+  # Adds default headers to the request.
+  #
+  # ## Parameters
+  #
+  #   * `additional_headers` - List of additional headers to include
+  #
+  # ## Examples
+  #
+  #     headers([{"x-forwarded-for", "127.0.0.1"}])
   @spec headers(headers()) :: headers()
   defp headers(additional_headers \\ []) do
     Enum.concat(additional_headers || [], [{"content-type", "application/json"}])

--- a/lib/posthog/guard.ex
+++ b/lib/posthog/guard.ex
@@ -1,0 +1,32 @@
+defmodule Posthog.Guard do
+  @moduledoc """
+  Custom guards for the Posthog library.
+
+  This module contains guard expressions that can be used across the Posthog library
+  for consistent pattern matching and type checking.
+  """
+
+  @doc """
+  Guard that checks if a term is a keyword list.
+
+  A keyword list is a list of 2-tuples where the first element of each tuple
+  is an atom.
+
+  ## Examples
+
+      iex> import Posthog.Guard
+      iex> match?({:ok, val} when is_keyword_list(val), {:ok, [foo: 1, bar: 2]})
+      true
+      iex> match?({:ok, val} when is_keyword_list(val), {:ok, [1, 2, 3]})
+      false
+      iex> match?({:ok, val} when is_keyword_list(val), {:ok, []})
+      false
+      iex> match?({:ok, val} when is_keyword_list(val), {:ok, [{:a, 1}, {:b, 2}]})
+      true
+      iex> match?({:ok, val} when is_keyword_list(val), {:ok, %{a: 1}})
+      false
+  """
+  defguard is_keyword_list(term)
+           when is_list(term) and length(term) > 0 and
+                  elem(hd(term), 0) |> is_atom() and tuple_size(hd(term)) == 2
+end

--- a/lib/posthog/guard.ex
+++ b/lib/posthog/guard.ex
@@ -19,12 +19,8 @@ defmodule Posthog.Guard do
       true
       iex> match?({:ok, val} when is_keyword_list(val), {:ok, [1, 2, 3]})
       false
-      iex> match?({:ok, val} when is_keyword_list(val), {:ok, []})
-      false
       iex> match?({:ok, val} when is_keyword_list(val), {:ok, [{:a, 1}, {:b, 2}]})
       true
-      iex> match?({:ok, val} when is_keyword_list(val), {:ok, %{a: 1}})
-      false
   """
   defguard is_keyword_list(term)
            when is_list(term) and length(term) > 0 and

--- a/test/posthog/client_test.exs
+++ b/test/posthog/client_test.exs
@@ -49,5 +49,29 @@ defmodule Posthog.ClientTest do
       assert event.properties["$lib"] == "custom"
       assert event.properties["$lib_version"] == "1.0.0"
     end
+
+    test "properties are converted from atom keys to string keys" do
+
+      event = Client.build_event(
+        "test_event",
+        %{
+          foo: "bar",
+          nested: %{
+            atom_key: 123
+          },
+        },
+        "2024-03-20"
+      )
+      assert event.properties == %{
+        "foo" => "bar",
+        "$lib" => "posthog-elixir",
+        "$lib_version" => Mix.Project.config()[:version],
+        "nested" => %{
+          "atom_key" => 123
+        },
+      }
+
+    end
   end
+
 end

--- a/test/posthog/client_test.exs
+++ b/test/posthog/client_test.exs
@@ -57,7 +57,9 @@ defmodule Posthog.ClientTest do
           %{
             foo: "bar",
             nested: %{
-              atom_key: 123
+              atom_key: 123,
+              list: [1, 2, 3],
+              keyword_list: [a: 1, b: 2]
             }
           },
           "2024-03-20"
@@ -68,7 +70,9 @@ defmodule Posthog.ClientTest do
                "$lib" => "posthog-elixir",
                "$lib_version" => Mix.Project.config()[:version],
                "nested" => %{
-                 "atom_key" => 123
+                 "atom_key" => 123,
+                 "list" => [1, 2, 3],
+                 "keyword_list" => %{"a" => 1, "b" => 2}
                }
              }
     end

--- a/test/posthog/client_test.exs
+++ b/test/posthog/client_test.exs
@@ -51,27 +51,26 @@ defmodule Posthog.ClientTest do
     end
 
     test "properties are converted from atom keys to string keys" do
-
-      event = Client.build_event(
-        "test_event",
-        %{
-          foo: "bar",
-          nested: %{
-            atom_key: 123
+      event =
+        Client.build_event(
+          "test_event",
+          %{
+            foo: "bar",
+            nested: %{
+              atom_key: 123
+            }
           },
-        },
-        "2024-03-20"
-      )
-      assert event.properties == %{
-        "foo" => "bar",
-        "$lib" => "posthog-elixir",
-        "$lib_version" => Mix.Project.config()[:version],
-        "nested" => %{
-          "atom_key" => 123
-        },
-      }
+          "2024-03-20"
+        )
 
+      assert event.properties == %{
+               "foo" => "bar",
+               "$lib" => "posthog-elixir",
+               "$lib_version" => Mix.Project.config()[:version],
+               "nested" => %{
+                 "atom_key" => 123
+               }
+             }
     end
   end
-
 end

--- a/test/posthog/guard_test.exs
+++ b/test/posthog/guard_test.exs
@@ -1,0 +1,4 @@
+defmodule Posthog.GuardTest do
+  use ExUnit.Case, async: true
+  doctest Posthog.Guard
+end


### PR DESCRIPTION
See https://posthoghelp.zendesk.com/agent/tickets/27142 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/29371)