### PR TITLE
Don't nest custom properties under a "properties" key in docs

### DIFF
--- a/lib/posthog.ex
+++ b/lib/posthog.ex
@@ -33,10 +33,8 @@ defmodule Posthog do
       # Event with properties
       Posthog.capture("purchase", [
         distinct_id: "user_123",
-        properties: %{
-          product_id: "prod_123",
-          price: 99.99
-        }
+        product_id: "prod_123",
+        price: 99.99
       ])
 
       # Event with custom timestamp
@@ -74,7 +72,7 @@ defmodule Posthog do
 
       events = [
         {"page_view", [distinct_id: "user_123"], nil},
-        {"button_click", [distinct_id: "user_123", properties: %{button: "signup"}], nil}
+        {"button_click", [distinct_id: "user_123", button: "signup"], nil}
       ]
 
       Posthog.batch(events)
@@ -107,10 +105,8 @@ defmodule Posthog do
       # Event with properties
       Posthog.capture("purchase", [
         distinct_id: "user_123",
-        properties: %{
-          product_id: "prod_123",
-          price: 99.99
-        }
+        product_id: "prod_123",
+        price: 99.99
       ])
 
       # Event with timestamp
@@ -140,7 +136,7 @@ defmodule Posthog do
 
       events = [
         {"page_view", [distinct_id: "user_123"], nil},
-        {"button_click", [distinct_id: "user_123", properties: %{button: "signup"}], nil}
+        {"button_click", [distinct_id: "user_123", button: "signup"], nil}
       ]
 
       Posthog.batch(events)

--- a/lib/posthog/client.ex
+++ b/lib/posthog/client.ex
@@ -132,7 +132,8 @@ defmodule Posthog.Client do
       Posthog.Client.capture("purchase",
         %{
           distinct_id: "user_123",
-          properties: %{product_id: "123", price: 99.99}
+          product_id: "123",
+          price: 99.99
         },
         timestamp: DateTime.utc_now()
       )
@@ -166,7 +167,7 @@ defmodule Posthog.Client do
 
       events = [
         {"page_view", %{distinct_id: "user_123"}, nil},
-        {"click", %{distinct_id: "user_123", properties: %{button: "signup"}}, DateTime.utc_now()}
+        {"click", %{distinct_id: "user_123", button: "signup"}, DateTime.utc_now()}
       ]
 
       Posthog.Client.batch(events)


### PR DESCRIPTION
When I tested integrating this, if I call capture with my custom properties nested under a `properties` key like: 
```elixir
Posthog.capture("purchase", [
  distinct_id: "user_123",
  properties: %{
    product_id: "prod_123",
    price: 99.99
  }
])
```

Then all my values are nested in Posthog which means I cannot filter on individual properties.

So instead it seems more appropriate to directly send each property at the top-level like:

```elixir
Posthog.capture("purchase", [
  distinct_id: "user_123",
  product_id: "prod_123",
  price: 99.99
])
```

And that also matches the format in the example for `Posthog.Client.build_event/2`