### PR TITLE
fix: Fix demo variant handling

### DIFF
--- a/examples/feature_flag_demo/lib/feature_flag_demo.ex
+++ b/examples/feature_flag_demo/lib/feature_flag_demo.ex
@@ -3,17 +3,34 @@ defmodule FeatureFlagDemo do
   A simple console application to demonstrate PostHog feature flag functionality.
   """
 
+  @default_api_url "https://app.posthog.com"
+
   def main(args) do
-    # Print configuration for debugging
-    api_url = System.get_env("POSTHOG_API_URL", "https://app.posthog.com")
-    api_key = System.get_env("POSTHOG_API_KEY")
-
-    IO.puts("Using API URL: #{api_url}")
-    IO.puts("Using API Key: #{String.slice(api_key || "", 0, 8)}...") # Only show first 8 chars of key for security
-
+    print_info(:config)
     args
     |> parse_args()
     |> process()
+  end
+
+  defp print_info(:config) do
+    api_url = System.get_env("POSTHOG_API_URL", @default_api_url)
+    api_key = System.get_env("POSTHOG_API_KEY")
+
+    IO.puts("Using API URL: #{api_url}")
+    IO.puts("Using API Key: #{String.slice(api_key || "", 0, 8)}...")
+  end
+
+  defp print_info(:usage) do
+    IO.puts("""
+    Usage: mix run run.exs --flag FLAG_NAME --distinct-id USER_ID [options]
+
+    Options:
+      --flag FLAG_NAME              The name of the feature flag to check
+      --distinct-id USER_ID         The distinct ID of the user
+      --groups GROUPS               JSON string of group properties (optional)
+      --group_properties PROPERTIES JSON string of group properties (optional)
+      --person_properties PROPERTIES JSON string of person properties (optional)
+    """)
   end
 
   defp parse_args(args) do
@@ -32,82 +49,64 @@ defmodule FeatureFlagDemo do
     opts
   end
 
-  defp process([]) do
-    IO.puts("""
-    Usage: mix run run.exs --flag FLAG_NAME --distinct-id USER_ID [options]
+  defp process([]), do: print_info(:usage)
 
-    Options:
-      --flag FLAG_NAME              The name of the feature flag to check
-      --distinct-id USER_ID         The distinct ID of the user
-      --groups GROUPS               JSON string of group properties (optional)
-      --group_properties PROPERTIES JSON string of group properties (optional)
-      --person_properties PROPERTIES JSON string of person properties (optional)
+  defp process([flag: flag, distinct_id: distinct_id] = opts) do
+    IO.puts("Checking feature flag '#{flag}' for user '#{distinct_id}'...")
+
+    with {:ok, response} <- call_feature_flag(flag, distinct_id, opts),
+         {:ok, message} <- format_response(flag, response) do
+      IO.puts(message)
+    else
+      {:error, %{status: 403}} -> print_auth_error()
+      {:error, %{status: status, body: body}} -> IO.puts("Error: Received status #{status}\nResponse body: #{inspect(body)}")
+      {:error, reason} -> IO.puts("Error: #{inspect(reason)}")
+    end
+  end
+
+  defp process(_), do: print_info(:usage)
+
+  defp call_feature_flag(flag, distinct_id, opts) do
+    Posthog.feature_flag(flag, distinct_id,
+      groups: parse_json(opts[:groups]),
+      group_properties: parse_json(opts[:group_properties]),
+      person_properties: parse_json(opts[:person_properties])
+    )
+  end
+
+  defp format_response(flag, %{enabled: enabled, payload: payload}) do
+    message = case enabled do
+      true -> "Feature flag '#{flag}' is ENABLED"
+      false -> "Feature flag '#{flag}' is DISABLED"
+      variant when is_binary(variant) -> "Feature flag '#{flag}' is ENABLED with variant: #{variant}"
+    end
+
+    message = if payload, do: message <> "\nPayload: #{inspect(payload)}", else: message
+    {:ok, message}
+  end
+
+  defp print_auth_error do
+    IO.puts("""
+    Error: Authentication failed (403 Forbidden)
+
+    Please check that:
+    1. Your POSTHOG_API_KEY is set correctly
+    2. Your POSTHOG_API_URL is set correctly (if using a self-hosted instance)
+    3. The API key has the necessary permissions
+    4. Your local PostHog instance is running and accessible
+
+    You can set these environment variables:
+    export POSTHOG_API_KEY="your_project_api_key"
+    export POSTHOG_API_URL="http://localhost:8000"  # Note: no trailing slash
     """)
   end
 
-  defp process(opts) do
-    flag = Keyword.get(opts, :flag)
-    distinct_id = Keyword.get(opts, :distinct_id)
-
-    if is_nil(flag) or is_nil(distinct_id) do
-      IO.puts("Error: --flag and --distinct-id are both required")
-      process([])
-    else
-      check_feature_flag(flag, distinct_id, opts)
+  defp parse_json(value) do
+    case value do
+      nil -> nil
+      "" -> nil
+      json when is_binary(json) -> Jason.decode!(json)
+      other -> other
     end
   end
-
-  defp check_feature_flag(flag, distinct_id, opts) do
-    groups = parse_json(Keyword.get(opts, :groups))
-    group_properties = parse_json(Keyword.get(opts, :group_properties))
-    person_properties = parse_json(Keyword.get(opts, :person_properties))
-
-    IO.puts("Checking feature flag '#{flag}' for user '#{distinct_id}'...")
-
-    case Posthog.feature_flag(flag, distinct_id,
-           groups: groups,
-           group_properties: group_properties,
-           person_properties: person_properties
-         ) do
-      {:ok, %{enabled: true, payload: payload}} ->
-        IO.puts("Feature flag '#{flag}' is ENABLED")
-        IO.puts("Payload: #{inspect(payload)}")
-
-      {:ok, %{enabled: false}} ->
-        IO.puts("Feature flag '#{flag}' is DISABLED")
-
-      {:ok, %{enabled: variant, payload: payload}} when is_binary(variant) ->
-        IO.puts("Feature flag '#{flag}' is ENABLED with variant: #{variant}")
-        if payload, do: IO.puts("Payload: #{inspect(payload)}")
-
-      {:error, %{status: 403}} ->
-        IO.puts("""
-        Error: Authentication failed (403 Forbidden)
-
-        Please check that:
-        1. Your POSTHOG_API_KEY is set correctly
-        2. Your POSTHOG_API_URL is set correctly (if using a self-hosted instance)
-        3. The API key has the necessary permissions
-        4. Your local PostHog instance is running and accessible
-
-        You can set these environment variables:
-        export POSTHOG_API_KEY="your_project_api_key"
-        export POSTHOG_API_URL="http://localhost:8000"  # Note: no trailing slash
-        """)
-
-      {:error, %{status: status, body: body}} ->
-        IO.puts("""
-        Error: Received status #{status}
-        Response body: #{inspect(body)}
-        """)
-
-      {:error, reason} ->
-        IO.puts("Error: #{inspect(reason)}")
-    end
-  end
-
-  defp parse_json(nil), do: nil
-  defp parse_json(""), do: nil
-  defp parse_json(json) when is_binary(json), do: Jason.decode!(json)
-  defp parse_json(value), do: value
 end

--- a/examples/feature_flag_demo/lib/feature_flag_demo.ex
+++ b/examples/feature_flag_demo/lib/feature_flag_demo.ex
@@ -76,6 +76,10 @@ defmodule FeatureFlagDemo do
       {:ok, %{enabled: false}} ->
         IO.puts("Feature flag '#{flag}' is DISABLED")
 
+      {:ok, %{enabled: variant, payload: payload}} when is_binary(variant) ->
+        IO.puts("Feature flag '#{flag}' is ENABLED with variant: #{variant}")
+        if payload, do: IO.puts("Payload: #{inspect(payload)}")
+
       {:error, %{status: 403}} ->
         IO.puts("""
         Error: Authentication failed (403 Forbidden)
@@ -98,15 +102,12 @@ defmodule FeatureFlagDemo do
         """)
 
       {:error, reason} ->
-        IO.puts("Error checking feature flag: #{inspect(reason)}")
+        IO.puts("Error: #{inspect(reason)}")
     end
   end
 
-  defp parse_json(nil), do: %{}
-  defp parse_json(json) when is_binary(json) do
-    case Jason.decode(json) do
-      {:ok, result} -> result
-      {:error, _} -> %{}
-    end
-  end
+  defp parse_json(nil), do: nil
+  defp parse_json(""), do: nil
+  defp parse_json(json) when is_binary(json), do: Jason.decode!(json)
+  defp parse_json(value), do: value
 end


### PR DESCRIPTION
When running the sample demo with a flag that returns a variant string, the existing code doesn't handle it well. With this change, we handle it well.