### PR TITLE
chore: change guidance on starting application

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,62 +27,6 @@ def deps do
 end
 ```
 
-You'll also need to include this library under your application tree. You can do so by including `:posthog` under your `:extra_applications` key inside `mix.exs`
-
-```elixir
-# mix.exs
-def application do
-  [
-    extra_applications: [
-      # ... your existing applications
-      :posthog
-    ]
-  ]
-```
-
-or if you already have a `YourApp.Application` application, you can also add `Posthog.Application` under your supervision tree:
-
-```elixir
-# lib/my_app/application.ex
-defmodule MyApp.Application do
-  use Application
-
-  def start(_type, _args) do
-    children = [
-      # Your other children...
-      {Posthog.Application, []}
-    ]
-
-    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
-end
-```
-
-### Application Customization
-
-This library includes a `Posthog.Application` because we bundle `Cachex` to allow you to track inside PostHog your FF usage.
-
-This cache is located under `:posthog_feature_flag_cache`. If you want more control over the application, you can init it yourself in your own `application.ex`
-
-```elixir
-# lib/my_app/application.ex
-
-defmodule MyApp.Application do
-  use Application
-
-  def start(_type, _args) do
-    children = [
-      # Your other application children...
-      {Posthog.Application, []}
-    ]
-
-    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
-end
-```
-
 ## Configuration
 
 Add your PostHog configuration to your application's config:


### PR DESCRIPTION
Hello, thank you for the Elixir client library for Posthog! I am evaluating Posthog for my business, [TV Labs](https://tvlabs.ai), and after doing due-diligence, I wanted to send a few improvements. (This is the first)

Since [Elixir 1.4 (January, 2017)](https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/#application-inference), Elixir automatically starts all Applications in your dependencies. Adding `:posthog` to your `:extra_applications` is thus unnecessary, and probably bad advice for new-comers to the language. 

Starting it as part of your application supervision tree is also probably misguided.

As an aside, if this library wanted to give users more control over supervising their instance, it should not start an application, and instead expose a root GenServer where all configuration is passed.