### PR TITLE
event: add clause to serialize structs which implement String.Chars

### DIFF
--- a/lib/posthog/event.ex
+++ b/lib/posthog/event.ex
@@ -149,10 +149,17 @@ defmodule Posthog.Event do
   end
 
   @doc false
-  defp deep_stringify_keys(term) when is_map(term) do
+  defp deep_stringify_keys(term) when is_non_struct_map(term) do
     term
     |> Enum.map(fn {k, v} -> {to_string(k), deep_stringify_keys(v)} end)
     |> Enum.into(%{})
+  end
+
+  defp deep_stringify_keys(term) when is_struct(term) do
+    case String.Chars.impl_for(term) do
+      nil -> Map.from_struct(term)
+      _ -> to_string(term)
+    end
   end
 
   defp deep_stringify_keys([{key, _value} | _] = term) when is_atom(key) do


### PR DESCRIPTION
After upgrading to posthog-elixir to 1.0.2 our implementation was broken because we were passing Money structs from ex_money as data in Posthog.Client.batch. I think previously somehow our system was properly converting the structs into strings (Money implements the String.Chars protocol).

It was failing with the following:
```
** (Protocol.UndefinedError) protocol Enumerable not implemented for Money.new(:USD, "2") of type Money (a struct). This protocol is implemented for the following type(s): DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Iter, Jason.OrderedObject, List, Map, MapSet, Phoenix.LiveView.LiveStream, Postgrex.Stream, Range, Req.Response.Async, Rewrite, Stream, StreamData, Timex.Interval
    (elixir 1.17.3) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.17.3) lib/enum.ex:166: Enumerable.reduce/3
    (elixir 1.17.3) lib/enum.ex:4423: Enum.map/2
    (posthog 1.0.2) lib/posthog/event.ex:156: Posthog.Event.deep_stringify_keys/1
    (posthog 1.0.2) lib/posthog/event.ex:156: anonymous fn/1 in Posthog.Event.deep_stringify_keys/1
    (elixir 1.17.3) lib/enum.ex:1711: anonymous fn/3 in Enum.map/2
    (stdlib 6.1.2) maps.erl:860: :maps.fold_1/4
    (elixir 1.17.3) lib/enum.ex:2543: Enum.map/2
    (posthog 1.0.2) lib/posthog/event.ex:156: Posthog.Event.deep_stringify_keys/1
    (posthog 1.0.2) lib/posthog/event.ex:139: Posthog.Event.to_api_payload/1
    (elixir 1.17.3) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (posthog 1.0.2) lib/posthog/event.ex:150: Posthog.Event.batch_payload/1
    (posthog 1.0.2) lib/posthog/client.ex:237: Posthog.Client.batch/
```

I added a clause which would test if a struct implements String.Chars and if not would pass the term as a map back into the head of the function.

I tested that this would work for my situation, but this logic could use some double checking.