### PR TITLE
Expose `capture/2`

### DIFF
--- a/lib/posthog.ex
+++ b/lib/posthog.ex
@@ -144,7 +144,7 @@ defmodule Posthog do
 
   @spec capture(Client.event(), Client.distinct_id(), Client.properties(), Client.opts()) ::
           Client.result()
-  defdelegate capture(event, distinct_id, properties, opts \\ []), to: Client
+  defdelegate capture(event, distinct_id, properties \\ %{}, opts \\ []), to: Client
 
   @doc """
   Sends multiple events to PostHog in a single request.


### PR DESCRIPTION
The examples and docs all use it, but the `defdelegate` is hiding the 2 arity version. This makes it available for calling.

Before:

```
iex(2)> Posthog.capture("page_view", "user_123")
** (UndefinedFunctionError) function Posthog.capture/2 is undefined or private. Did you mean:

      * capture/3
      * capture/4

    (posthog 1.0.3) Posthog.capture("page_view", "user_123")
    iex:2: (file)
```

After:

```
iex(1)> Posthog.capture("page_view", "user_123")
{:ok,
 %{
   status: 200,
   body: %{"status" => "Ok"},
   headers: [
     {"Date", "Tue, 01 Jul 2025 05:45:56 GMT"},
     {"Content-Type", "application/json"},
     {"Content-Length", "15"},
     {"Connection", "keep-alive"},
     {"vary",
      "origin, access-control-request-method, access-control-request-headers"},
     {"access-control-allow-credentials", "true"},
     {"x-envoy-upstream-service-time", "64"},
     {"server", "envoy"},
     {"Strict-Transport-Security", "max-age=31536000; includeSubDomains"}
   ]
 }}
```