### PR TITLE
Encode properties for safe posting

### DIFF
--- a/lib/posthog.ex
+++ b/lib/posthog.ex
@@ -59,7 +59,11 @@ defmodule PostHog do
   @spec bare_capture(supervisor_name(), event(), distinct_id(), properties()) :: :ok
   def bare_capture(name \\ __MODULE__, event, distinct_id, properties \\ %{}) do
     config = PostHog.Registry.config(name)
-    properties = Map.merge(properties, config.global_properties)
+
+    properties =
+      properties
+      |> Map.merge(config.global_properties)
+      |> LoggerJSON.Formatter.RedactorEncoder.encode([])
 
     event = %{
       event: event,

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -85,6 +85,24 @@ defmodule PostHogTest do
       assert %{foo: "bar", "$lib": "posthog-elixir", "$lib_version": _} = properties
       refute properties[:hello]
     end
+
+    test "encodes properties for safe json serialization" do
+      PostHog.bare_capture("case tested", "distinct_id", %{
+        struct: %LoggerHandlerKit.FakeStruct{},
+        ref: make_ref()
+      })
+
+      assert [event] = all_captured()
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{struct: %{hello: nil}, ref: _} = properties,
+               timestamp: _
+             } = event
+
+      JSON.encode!(properties)
+    end
   end
 
   describe "capture/4" do


### PR DESCRIPTION
Properties must be JSON-serializable to be posted. Ideally, users should be intentional about what they post and sure this, but in reality, people want to drop arbitrary terms in properties. So let's encode them with `LoggerJSON` encoder.