### PR TITLE
Expose global properties configuration option

### DIFF
--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -70,7 +70,7 @@ defmodule PostHog.Config do
 
   @compiled_configuration_schema NimbleOptions.new!(@configuration_schema)
   @compiled_convenience_schema NimbleOptions.new!(@convenience_schema)
-  
+
   @system_global_properties %{
     "$lib": "posthog-elixir",
     "$lib_version": Mix.Project.config()[:version]

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -70,6 +70,11 @@ defmodule PostHog.Config do
 
   @compiled_configuration_schema NimbleOptions.new!(@configuration_schema)
   @compiled_convenience_schema NimbleOptions.new!(@convenience_schema)
+  
+  @system_global_properties %{
+    "$lib": "posthog-elixir",
+    "$lib_version": Mix.Project.config()[:version]
+  }
 
   @moduledoc """
   PostHog configuration
@@ -139,12 +144,7 @@ defmodule PostHog.Config do
     with {:ok, validated} <- NimbleOptions.validate(options, @compiled_configuration_schema) do
       config = Map.new(validated)
       client = config.api_client_module.client(config.api_key, config.public_url)
-
-      global_properties =
-        Map.merge(config.global_properties, %{
-          "$lib": "posthog-elixir",
-          "$lib_version": Application.spec(:posthog, :vsn) |> to_string()
-        })
+      global_properties = Map.merge(config.global_properties, @system_global_properties)
 
       final_config =
         config

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -33,6 +33,7 @@ defmodule PostHog.HandlerTest do
            } = event
   end
 
+  @tag config: [global_properties: %{foo: "bar"}]
   test "always exports global context", %{
     handler_ref: ref,
     config: %{supervisor_name: supervisor_name}
@@ -47,6 +48,7 @@ defmodule PostHog.HandlerTest do
              properties: %{
                "$lib": "posthog-elixir",
                "$lib_version": _,
+               foo: "bar",
                "$exception_list": [
                  %{
                    type: "Hello World",

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -46,7 +46,10 @@ defmodule PostHogTest do
              } = event
     end
 
-    @tag config: [global_properties: %{egg: "spam"}, supervisor_name: PostHog]
+    @tag config: [
+           global_properties: %{egg: "spam", struct: %LoggerHandlerKit.FakeStruct{}},
+           supervisor_name: PostHog
+         ]
     test "adds global properties" do
       PostHog.bare_capture("case tested", "distinct_id")
 
@@ -55,9 +58,16 @@ defmodule PostHogTest do
       assert %{
                event: "case tested",
                distinct_id: "distinct_id",
-               properties: %{egg: "spam", "$lib": "posthog-elixir", "$lib_version": _},
+               properties: %{
+                 egg: "spam",
+                 struct: %{hello: nil},
+                 "$lib": "posthog-elixir",
+                 "$lib_version": _
+               },
                timestamp: _
              } = event
+
+      JSON.encode!(event)
     end
 
     @tag config: [supervisor_name: CustomPostHog]

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -46,6 +46,20 @@ defmodule PostHogTest do
              } = event
     end
 
+    @tag config: [global_properties: %{egg: "spam"}, supervisor_name: PostHog]
+    test "adds global properties" do
+      PostHog.bare_capture("case tested", "distinct_id")
+
+      assert [event] = all_captured()
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{egg: "spam", "$lib": "posthog-elixir", "$lib_version": _},
+               timestamp: _
+             } = event
+    end
+
     @tag config: [supervisor_name: CustomPostHog]
     test "simple call for custom supervisor" do
       PostHog.bare_capture(CustomPostHog, "case tested", "distinct_id")


### PR DESCRIPTION
Global properties were already a thing in the library, we used them to send `$lib` and `$lib_version`, but it makes sense to expose them to users as well. In my particular use case, we want to add a property with team member name to distinguish events in dev. 