### PR TITLE
Let users export all Logger metadata keys in Error Tracking

### DIFF
--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -32,9 +32,10 @@ defmodule PostHog.Config do
                             doc: "Name of the supervisor process running PostHog"
                           ],
                           metadata: [
-                            type: {:list, :atom},
+                            type: {:or, [{:list, :atom}, {:in, [:all]}]},
                             default: [],
-                            doc: "List of metadata keys to include in event properties"
+                            doc:
+                              "List of Logger metadata keys to include in event properties. Set to `:all` to include all metadata. This only affects Error Tracking events."
                           ],
                           capture_level: [
                             type: {:or, [{:in, Logger.levels()}, nil]},

--- a/lib/posthog/context.ex
+++ b/lib/posthog/context.ex
@@ -3,6 +3,8 @@ defmodule PostHog.Context do
 
   @logger_metadata_key :__posthog__
 
+  def logger_metadata_key(), do: @logger_metadata_key
+
   def set(name_scope, event_scope \\ :all, context) do
     metadata =
       with :undefined <- :logger.get_process_metadata(), do: %{}

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -49,7 +49,13 @@ defmodule PostHog.Handler do
 
     metadata =
       log_event.meta
-      |> Map.take([:distinct_id | config.metadata])
+      |> then(fn metadata ->
+        if config.metadata == :all do
+          Map.delete(metadata, Context.logger_metadata_key())
+        else
+          Map.take(metadata, [:distinct_id | config.metadata])
+        end
+      end)
       |> Map.drop(["$exception_list"])
       |> LoggerJSON.Formatter.RedactorEncoder.encode([])
 

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -915,6 +915,39 @@ defmodule PostHog.HandlerTest do
            } = event
   end
 
+  @tag config: [metadata: :all]
+  test "exports all metadata if configured", %{
+    handler_ref: ref,
+    config: %{supervisor_name: supervisor_name}
+  } do
+    PostHog.set_context(supervisor_name, %{should: "work"})
+    PostHog.set_context(%{shouldnt: "work"})
+    Logger.metadata(foo: "bar")
+    Logger.error("Error with metadata", hello: "world")
+    LoggerHandlerKit.Assert.assert_logged(ref)
+
+    assert [event] = all_captured(supervisor_name)
+
+    assert %{
+             event: "$exception",
+             properties:
+               %{
+                 hello: "world",
+                 foo: "bar",
+                 should: "work",
+                 "$exception_list": [
+                   %{
+                     type: "Error with metadata",
+                     value: "Error with metadata",
+                     mechanism: %{handled: true}
+                   }
+                 ]
+               } = properties
+           } = event
+
+    refute Map.has_key?(properties, :shouldnt)
+  end
+
   @tag config: [metadata: [:extra]]
   test "ensures metadata is serializable", %{
     handler_ref: ref,


### PR DESCRIPTION
Although having an explicit list of metadata keys to export is the baseline, for production environment people usually just export all metadata. This is why libraries that support this usually allow [`:all` option](https://hexdocs.pm/logger_json/LoggerJSON.html#module-shared-options) and even more sophisticated ones. I'm fairly sure supporting `:all` is a must have for the release, so let's add it!