### PR TITLE
Make Plug integration work for all events, not just errors

### DIFF
--- a/lib/posthog/integrations/plug.ex
+++ b/lib/posthog/integrations/plug.ex
@@ -26,7 +26,7 @@ defmodule PostHog.Integrations.Plug do
   @doc false
   def call(conn, _opts) do
     context = conn_to_context(conn)
-    PostHog.Context.set(:all, "$exception", context)
+    PostHog.Context.set(:all, :all, context)
 
     conn
   end

--- a/test/posthog/integrations/plug_test.exs
+++ b/test/posthog/integrations/plug_test.exs
@@ -25,7 +25,7 @@ defmodule PostHog.Integrations.PlugTest do
     conn = Plug.Test.conn(:get, "https://posthog.com/foo?bar=10")
     assert PostHog.Integrations.Plug.call(conn, nil)
 
-    assert PostHog.Context.get(:all, "$exception") == %{
+    assert PostHog.Context.get(:all) == %{
              "$current_url": "https://posthog.com/foo?bar=10",
              "$host": "posthog.com",
              "$ip": "127.0.0.1",


### PR DESCRIPTION
Plug integrations was made to be pretty conservative and only enrich `$exception` events, but in reality all events will benefit from ips and paths. 