### PR TITLE
Ensure `file` metadata is converted to binary

### DIFF
--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -57,7 +57,7 @@ defmodule PostHog.Handler do
         end
       end)
       |> Map.drop(["$exception_list"])
-      |> LoggerJSON.Formatter.RedactorEncoder.encode([])
+      |> maybe_update_file_key()
 
     Context.get(config.supervisor_name, "$exception")
     |> enrich_context(log_event)
@@ -160,4 +160,12 @@ defmodule PostHog.Handler do
   end
 
   defp enrich_context(context, _log_event), do: context
+
+  defp maybe_update_file_key(%{file: chardata} = metadata) when is_list(chardata) do
+    Map.update!(metadata, :file, &IO.chardata_to_string/1)
+  rescue
+    _ -> metadata
+  end
+
+  defp maybe_update_file_key(metadata), do: metadata
 end

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -950,6 +950,29 @@ defmodule PostHog.HandlerTest do
     refute Map.has_key?(properties, :shouldnt)
   end
 
+  @tag config: [metadata: :all]
+  test "updates file metadata to be a string", %{
+    handler_ref: ref,
+    config: %{supervisor_name: supervisor_name}
+  } do
+    Logger.error("Error with default metadata")
+    LoggerHandlerKit.Assert.assert_logged(ref)
+
+    assert [%{properties: %{file: file}}] = all_captured(supervisor_name)
+    assert is_binary(file)
+  end
+
+  @tag config: [metadata: :all]
+  test "noop if file is non chardata", %{
+    handler_ref: ref,
+    config: %{supervisor_name: supervisor_name}
+  } do
+    Logger.error("Error with default metadata", file: 123)
+    LoggerHandlerKit.Assert.assert_logged(ref)
+
+    assert [%{properties: %{file: 123}}] = all_captured(supervisor_name)
+  end
+
   @tag config: [metadata: [:extra]]
   test "ensures metadata is serializable", %{
     handler_ref: ref,


### PR DESCRIPTION
If user chooses to export built-in `file` metadata, they face a problem: file name is a chardata, which is indistinguishable from list of integers for both JSON encoder and `LoggerJSON` redactor/encoder. Basically, we just know that in this particular part of the code it's a chardata and we need to give this key a special treatment ([which is a common thing to do](https://github.com/Nebo15/logger_json/pull/159))