### PR TITLE
refactor: Use standard `api_host`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Configure the `PostHog` application environment:
 config :posthog,
   enable: true,
   enable_error_tracking: true,
-  public_url: "https://us.i.posthog.com", # Or `https://eu.posthog.com` or your self-hosted PostHog instance URL
+  api_host: "https://us.i.posthog.com", # Or `https://eu.posthog.com` or your self-hosted PostHog instance URL
   api_key: "phc_my_api_key",
   in_app_otp_apps: [:my_app]
 ```
@@ -215,6 +215,6 @@ minimal example:
 import Config
 
 config :posthog,
-  public_url: "https://us.i.posthog.com",
+  api_host: "https://us.i.posthog.com",
   api_key: "phc_XXXX"
 ```

--- a/config/integration.example.exs
+++ b/config/integration.example.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :posthog, :integration_config,
-  public_url: "https://us.i.posthog.com",
+  api_host: "https://us.i.posthog.com",
   api_key: "phc_mykey",
   metadata: [:extra],
   capture_level: :info,

--- a/guides/advanced-configuration.md
+++ b/guides/advanced-configuration.md
@@ -7,7 +7,7 @@ This behavior is configured by the `:posthog` option in your global configuratio
 config :posthog,
   enable: true,
   enable_error_tracking: true,
-  public_url: "https://us.i.posthog.com",
+  api_host: "https://us.i.posthog.com",
   api_key: "phc_asdf"
   ...
 ```
@@ -22,7 +22,7 @@ to your application tree with its own configuration:
 config :posthog, enable: false
 
 config :my_app, :posthog,
-  public_url: "https://us.i.posthog.com",
+  api_host: "https://us.i.posthog.com",
   api_key: "phc_asdf"
 
 # application.ex
@@ -32,7 +32,7 @@ defmodule MyApp.Application do
 
   def start(_type, _args) do
     posthog_config = Application.fetch_env!(:my_app, :posthog) |> PostHog.Config.validate!()
-    
+
     :logger.add_handler(:posthog, PostHog.Handler, %{config: posthog_config})
 
     children = [
@@ -53,21 +53,21 @@ one of which can be the default one:
 ```elixir
 # config.exs
 config :posthog,
-  public_url: "https://us.i.posthog.com",
+  api_host: "https://us.i.posthog.com",
   api_key: "phc_key1"
 
 config :my_app, :another_posthog,
-  public_url: "https://us.i.posthog.com",
+  api_host: "https://us.i.posthog.com",
   api_key: "phc_key2",
   supervisor_name: AnotherPostHog
-  
+
 # application.ex
 defmodule MyApp.Application do
   use Application
 
   def start(_type, _args) do
     posthog_config = Application.fetch_env!(:my_app, :another_posthog) |> PostHog.Config.validate!()
-    
+
     children = [
       {PostHog.Supervisor, posthog_config}
     ]

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -6,13 +6,13 @@ defmodule PostHog.API.Client do
   example just in case:
 
   ## Example
-    
+
       > client = PostHog.API.Client.client("phc_abcdedfgh", "https://us.i.posthog.com")
       %PostHog.API.Client{
         client: %Req.Request{...},
         module: PostHog.API.Client
       }
-      
+
       > client.module.request(client.client, :post, "/flags", json: %{distinct_id: "user123"}, params: %{v: 2, config: true})
       {:ok, %Req.Response{status: 200, body: %{...}}}
   """
@@ -46,9 +46,9 @@ defmodule PostHog.API.Client do
               response()
 
   @impl __MODULE__
-  def client(api_key, public_url) do
+  def client(api_key, api_host) do
     client =
-      Req.new(base_url: public_url)
+      Req.new(base_url: api_host)
       |> Req.Request.put_private(:api_key, api_key)
 
     %__MODULE__{client: client, module: __MODULE__}

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -8,7 +8,7 @@ defmodule PostHog.Config do
   ]
 
   @configuration_schema [
-                          public_url: [
+                          api_host: [
                             type: :string,
                             required: true,
                             doc:
@@ -144,7 +144,7 @@ defmodule PostHog.Config do
   def validate(options) do
     with {:ok, validated} <- NimbleOptions.validate(options, @compiled_configuration_schema) do
       config = Map.new(validated)
-      client = config.api_client_module.client(config.api_key, config.public_url)
+      client = config.api_client_module.client(config.api_key, config.api_host)
       global_properties = Map.merge(config.global_properties, @system_global_properties)
 
       final_config =

--- a/test/support/api/stub.ex
+++ b/test/support/api/stub.ex
@@ -2,7 +2,7 @@ defmodule PostHog.API.Stub do
   @behaviour PostHog.API.Client
 
   @impl PostHog.API.Client
-  def client(_api_key, _public_url) do
+  def client(_api_key, _api_host) do
     %PostHog.API.Client{client: :stub_client, module: PostHog.API.Mock}
   end
 

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -13,7 +13,7 @@ defmodule PostHog.Case do
 
     config =
       [
-        public_url: "https://us.i.posthog.com",
+        api_host: "https://us.i.posthog.com",
         api_key: "my_api_key",
         api_client_module: PostHog.API.Mock,
         supervisor_name: context[:test],


### PR DESCRIPTION
Rename `public_url` to `api_host` to match the name we have in other libraries. I agree this is not really "the host", but rather the full base url, but let's keep it consistent with other libraries for now