### PR TITLE
Pin Elixir version to 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,12 @@ jobs:
     # See https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
     strategy:
       matrix:
-        elixir: ["1.15.x", "1.16.x", "1.17.x", "1.18.x"]
-        otp: ["24.x", "25.x", "26.x", "27.x"]
+        elixir: ["1.17.x", "1.18.x"]
+        otp: ["25.x", "26.x", "27.x", "28.x"]
         exclude:
-          # Elixir 1.17 and 1.18 don't support OTP 24
+          # Elixir 1.17 doesn't support OTP 28
           - elixir: "1.17.x"
-            otp: "24.x"
-          - elixir: "1.18.x"
-            otp: "24.x"
-          # Elixir 1.15 and 1.16 don't support OTP 27
-          - elixir: "1.15.x"
-            otp: "27.x"
-          - elixir: "1.16.x"
-            otp: "27.x"
+            otp: "28.x"
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Huge thanks to community member [@martosaur](https://github.com/martosaur) for c
 
 ### What's new
 
-- Elixir v1.15+ required
+- Elixir v1.17+ required
 - Event capture is now offloaded to background workers with automatic batching
 - [Context](README.md#context) mechanism for easier property propagation
 - [Error Tracking](README.md#error-tracking) support

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -1,12 +1,3 @@
-# `Logger.levels/0` is not available in Elixir 1.15.0 so let's backport it
-# TODO: Remove this once we drop support for Elixir 1.15.0
-logger_levels =
-  if function_exported?(Logger, :levels, 0) do
-    Logger.levels()
-  else
-    [:emergency, :alert, :critical, :error, :warning, :warn, :notice, :info, :debug]
-  end
-
 defmodule PostHog.Config do
   @shared_schema [
     test_mode: [
@@ -47,7 +38,7 @@ defmodule PostHog.Config do
                               "List of Logger metadata keys to include in event properties. Set to `:all` to include all metadata. This only affects Error Tracking events."
                           ],
                           capture_level: [
-                            type: {:or, [{:in, logger_levels}, nil]},
+                            type: {:or, [{:in, Logger.levels()}, nil]},
                             default: :error,
                             doc:
                               "Minimum level for logs that should be captured as errors. Errors with `crash_reason` are always captured."

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule PostHog.MixProject do
     [
       app: :posthog,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -1013,7 +1013,7 @@ defmodule PostHog.HandlerTest do
 
     # Guarantee it's serializable
     # TODO: Migrate to JSON.encode! once we move to Elixir 1.18+
-    assert LoggerJSON.Formatter.RedactorEncoder.encode(maybe_encoded, [])
+    assert LoggerJSON.Formatter.RedactorEncoder.encode(maybe_encoded)
   end
 
   @tag config: [metadata: [:extra]]

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -1011,7 +1011,7 @@ defmodule PostHog.HandlerTest do
              port: "#Port<" <> _
            } = maybe_encoded
 
-    JSON.encode!(maybe_encoded)
+    Jason.encode!(maybe_encoded)
   end
 
   @tag config: [metadata: [:extra]]

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -1011,9 +1011,7 @@ defmodule PostHog.HandlerTest do
              port: "#Port<" <> _
            } = maybe_encoded
 
-    # Guarantee it's serializable
-    # TODO: Migrate to JSON.encode! once we move to Elixir 1.18+
-    assert LoggerJSON.Formatter.RedactorEncoder.encode(maybe_encoded)
+    JSON.encode!(maybe_encoded)
   end
 
   @tag config: [metadata: [:extra]]

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -67,7 +67,7 @@ defmodule PostHogTest do
                timestamp: _
              } = event
 
-      JSON.encode!(event)
+      Jason.encode!(event)
     end
 
     @tag config: [supervisor_name: CustomPostHog]
@@ -123,7 +123,7 @@ defmodule PostHogTest do
                timestamp: _
              } = event
 
-      JSON.encode!(properties)
+      Jason.encode!(properties)
     end
   end
 

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -67,9 +67,7 @@ defmodule PostHogTest do
                timestamp: _
              } = event
 
-      # Guarantee it's serializable
-      # TODO: Migrate to JSON.encode! once we move to Elixir 1.18+
-      assert LoggerJSON.Formatter.RedactorEncoder.encode(event)
+      JSON.encode!(event)
     end
 
     @tag config: [supervisor_name: CustomPostHog]
@@ -125,9 +123,7 @@ defmodule PostHogTest do
                timestamp: _
              } = event
 
-      # Guarantee it's serializable
-      # TODO: Migrate to JSON.encode! once we move to Elixir 1.18+
-      assert LoggerJSON.Formatter.RedactorEncoder.encode(event)
+      JSON.encode!(properties)
     end
   end
 

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -69,7 +69,7 @@ defmodule PostHogTest do
 
       # Guarantee it's serializable
       # TODO: Migrate to JSON.encode! once we move to Elixir 1.18+
-      assert LoggerJSON.Formatter.RedactorEncoder.encode(event, [])
+      assert LoggerJSON.Formatter.RedactorEncoder.encode(event)
     end
 
     @tag config: [supervisor_name: CustomPostHog]
@@ -127,7 +127,7 @@ defmodule PostHogTest do
 
       # Guarantee it's serializable
       # TODO: Migrate to JSON.encode! once we move to Elixir 1.18+
-      assert LoggerJSON.Formatter.RedactorEncoder.encode(event, [])
+      assert LoggerJSON.Formatter.RedactorEncoder.encode(event)
     end
   end
 

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -121,7 +121,7 @@ defmodule PostHogTest do
       assert %{
                event: "case tested",
                distinct_id: "distinct_id",
-               properties: %{struct: %{hello: nil}, ref: _},
+               properties: %{struct: %{hello: nil}, ref: _} = properties,
                timestamp: _
              } = event
 


### PR DESCRIPTION
I tested locally against different OTP and Elixir versions and I think it only makes sense to support 1.17 (OTP 25). 1.16 didn't have error tracking, so pretty much all tests would have to be rewritten just so we could check if it works.

I reverted a couple of commits that didn't make much sense anymore. In particular, instead of `JSON` we can just use `Jason` for compatibility with 1.17. `LoggerJSON.ReadctorEncoder` doesn't actually serialize terms to json, it just ensures terms are json-serializable. 