### PR TITLE
Make dev.exs tweakable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ posthog-*.tar
 
 # Local Config
 config/integration.exs
+config/dev.override.exs

--- a/README.md
+++ b/README.md
@@ -207,13 +207,16 @@ cp config/integration.example.exs config/integration.exs
 mix test --only integration
 ```
 
-If you want to play with PostHog events in IEx, you'll need to tweak your local `config/dev.exs` pointing it to the instance of your liking. Here a
-minimal example:
+If you want to play with PostHog events in IEx, just create
+`config/dev.override.exs` and tweak it to point to the instance of your liking.
+This config will be gitignored. Here's a minimal example:
 
 ```elixir
+# config/dev.override.exs
 import Config
 
 config :posthog,
+  enable: true
   api_host: "https://us.i.posthog.com",
   api_key: "phc_XXXX"
 ```

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,5 @@
 import Config
 
-config :posthog, enable: false, test_mode: true
+config :posthog, enable: false
 
-if File.exists?("config/integration.exs"), do: import_config("integration.exs")
+if File.exists?("config/dev.override.exs"), do: import_config("dev.override.exs")


### PR DESCRIPTION
Good catch on the fact that without `dev.exs` the app won't work. But now we can't tweak it because it's not gitignored! One of the solutions is to import `dev.override.exs` if it exists.