### PR TITLE
Fix flaky 1.17 test

### DIFF
--- a/test/posthog/feature_flags_test.exs
+++ b/test/posthog/feature_flags_test.exs
@@ -1,5 +1,6 @@
 defmodule PostHog.FeatureFlagsTest do
-  use PostHog.Case, async: true, group: PostHog
+  # group only works for Elixir 1.18, can't make it async until then
+  use PostHog.Case, async: false, group: PostHog
 
   @moduletag config: [supervisor_name: PostHog]
 

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -1,5 +1,6 @@
 defmodule PostHogTest do
-  use PostHog.Case, async: true, group: PostHog
+  # group only works for Elixir 1.18, can't make it async until then
+  use PostHog.Case, async: false, group: PostHog
 
   @moduletag config: [supervisor_name: PostHog]
 


### PR DESCRIPTION
One thing I forgot about 1.17, is that it doesn't have `group` for ExUnit. That's why https://github.com/PostHog/posthog-elixir/actions/runs/18150569276/job/51660693393?pr=56 this is flaky