### PR TITLE
Fix flaky sender test

### DIFF
--- a/test/posthog/sender_test.exs
+++ b/test/posthog/sender_test.exs
@@ -179,6 +179,7 @@ defmodule PostHog.SenderTest do
       [{^pid, :busy}] = Registry.lookup(registry, {PostHog.Sender, 1})
       send(pid, :go)
       assert_receive :done
+      :sys.get_status(pid)
       [{^pid, :available}] = Registry.lookup(registry, {PostHog.Sender, 1})
     end
 


### PR DESCRIPTION
We lookup Registry status faster than Sender can update it. The fix is to call `:sys.get_status(pid)` to ensure the callback finished before doing assertion.

https://github.com/PostHog/posthog-elixir/actions/runs/18151395886/job/51662911319#step:6:92