### PR TITLE
fix(test): use per-test registry to prevent flaky sender test

### DIFF
--- a/test/posthog/sender_test.exs
+++ b/test/posthog/sender_test.exs
@@ -8,7 +8,7 @@ defmodule PostHog.SenderTest do
 
   @supervisor_name __MODULE__
 
-  setup_all do
+  setup do
     registry = PostHog.Registry.registry_name(@supervisor_name)
 
     start_link_supervised!(


### PR DESCRIPTION
(saw this flake a few times in the past PRs this week)

## Root cause

`SenderTest` used `setup_all` to create one shared `Registry` for all tests. Elixir's `Registry` cleans up dead pids **asynchronously** — when a registered process dies, the registry server receives a `:DOWN` monitor message and removes the entry, but this happens in a separate message-passing step.

Test execution sequence that triggers the flake:

1. "picks available sender" runs — starts `Agent1` registered as `:available`
2. Test finishes, ExUnit kills the agents
3. "busy sender is ok if there are no available" starts **before** the registry processes the `:DOWN` for Agent1
4. `Sender.send` calls `Registry.select` → finds the still-registered (now-dead) Agent1 as `:available`
5. Dispatches the cast to the dead pid → message lost
6. `busy_pid`'s mailbox is empty → assertion fails

## Fix

Changed `setup_all` to `setup`. Each test now gets a fresh `Registry` instance, so there are no stale entries from previous tests.