### PR TITLE
chore: add GitHub community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner for everything in the repo, current maintainer
-* @rafaeelaudibert
+* @rafaeelaudibert @PostHog/team-client-libraries

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: 🐞 Bug Report
+description: Tell us about something that's not working the way we (probably) intend.
+labels: ["bug"]
+body:
+
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: SDK Version
+      placeholder: 3.0.0 ← should look like this
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce
+      description: How can we see what you're seeing? Specific is terrific.
+      placeholder: |-
+        1. foo
+        2. bar
+        3. baz
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: Logs? Screenshots? Yes, please.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask in the forums
+    url: https://posthog.com/questions
+    about: A place to ask questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: 💡 Feature Request
+description: Tell us about a problem our SDK could solve but doesn't.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem could we solve that it doesn't?
+      placeholder: |-
+        I want to make whirled peas, but it doesn't blend.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Solution Brainstorm
+      description: We know you have bright ideas to share ... share away, friend.
+      placeholder: |-
+        Add a blender to it.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.yml
@@ -1,0 +1,10 @@
+name: Blank Issue
+description: Blank Issue. Reserved for maintainers.
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe the issue.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,5 @@
 
 - [ ] Ran `sampo add` to generate a changeset file
 - [ ] Added the `release` label to the PR
-- [ ] The release will be approved via the GitHub `Release` environment
 
 <!-- For more details check README.md#releasing -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## :bulb: Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+
+## :green_heart: How did you test it?
+
+
+## :pencil: Checklist
+<!--- Put an `x` in the boxes that apply -->
+
+- [ ] I reviewed the submitted code.
+- [ ] I added tests to verify the changes.
+- [ ] I updated the docs if needed.
+- [ ] No breaking change or entry added to the changelog.
+
+### If releasing new changes
+
+- [ ] Ran `sampo add` to generate a changeset file
+- [ ] Added the `release` label to the PR
+- [ ] The release will be approved via the GitHub `Release` environment
+
+<!-- For more details check README.md#releasing -->


### PR DESCRIPTION
## :bulb: Motivation and Context
Align this repository with the standard PostHog client library GitHub metadata by adding any missing community health files and ensuring `@PostHog/team-client-libraries` is included in CODEOWNERS.

## :green_heart: How did you test it?
Not run. These are GitHub metadata and template changes only.

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
