### PR TITLE
chore: update branch references to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Release"
 on:
   pull_request:
     types: [closed]
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -19,7 +19,7 @@ jobs:
   check-release-label:
     name: Check for release label
     runs-on: ubuntu-latest
-    # Run when PR with 'release' label is merged to master
+    # Run when PR with 'release' label is merged to main
     if: |
       github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'pull_request' &&
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
 
       - name: Check release conditions
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
           fetch-depth: 0
           token: ${{ steps.releaser.outputs.token }}
 
@@ -150,7 +150,7 @@ jobs:
             echo "committed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: Release v${NEW_VERSION}"
-            git push origin master
+            git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   compliance:

--- a/.sampo/config.toml
+++ b/.sampo/config.toml
@@ -2,7 +2,7 @@
 version = 1
 
 [git]
-default_branch = "master"
+default_branch = "main"
 short_tags = "posthog"    # Tag with v1.2.3 rather than posthog-v1.2.3
 
 [github]

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ the [PostHog SDK releases process](https://posthog.com/handbook/engineering/sdks
 
 1. **Add a changeset** to your PR describing the changes (see above)
 2. **Add the `release` label** to the PR when it's ready for release
-3. **Merge the PR** into `master`
+3. **Merge the PR** into `main`
 
 Once merged, the release workflow will automatically:
 


### PR DESCRIPTION
## :bulb: Motivation and Context
This repo was still using `master` as the default branch. This updates the CI, release workflow, SDK compliance workflow, Sampo config, and release docs so the repository can use `main` consistently.

## :green_heart: How did you test it?
- Ran `git diff --check`
- Searched the repo for remaining branch-name references with `rg --hidden '\bmaster\b'`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR