### PR TITLE
docs: move release guide to RELEASING.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,4 +19,4 @@
 - [ ] Ran `sampo add` to generate a changeset file
 - [ ] Added the `release` label to the PR
 
-<!-- For more details check README.md#releasing -->
+<!-- For more details check RELEASING.md -->

--- a/README.md
+++ b/README.md
@@ -301,46 +301,4 @@ We welcome contributions! Here's how to get started:
 3. Run `mix format` and `mix credo --strict` to ensure code quality
 4. Open a Pull Request
 
-### Creating Changesets
-
-When making changes that should be included in the changelog, create a changeset:
-
-```bash
-# Install sampo CLI (requires Rust toolchain)
-cargo install sampo
-
-# Create a changeset describing your change
-sampo add
-```
-
-Follow the prompts to specify:
-
-- The type of change (`patch`, `minor`, or `major`)
-- A description of the change for the changelog
-
-Changesets are stored in `.sampo/changesets/` and will be consumed during the release process.
-
-## Releasing
-
-Releases are semi-automated using [Sampo](https://github.com/PostHog/sampo) and follow
-the [PostHog SDK releases process](https://posthog.com/handbook/engineering/sdks/releases).
-
-### How to trigger a release
-
-1. **Add a changeset** to your PR describing the changes (see above)
-2. **Add the `release` label** to the PR when it's ready for release
-3. **Merge the PR** into `main`
-
-Once merged, the release workflow will automatically:
-
-- Consume all pending changesets
-- Update the version in `mix.exs`
-- Update `CHANGELOG.md` with the new entries
-- Create a Git tag (e.g., `v2.2.0`)
-- Create a GitHub Release with generated notes
-- Publish the package to [Hex.pm](https://hex.pm/packages/posthog)
-
-### Release approval
-
-All releases require approval from the Client Libraries team via the `Release`
-GitHub environment. Release requests are posted to `#approvals-client-libraries` on Slack.
+For changeset and release instructions, see [RELEASING.md](RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,41 @@
+# Releasing
+
+Releases are semi-automated using [Sampo](https://github.com/PostHog/sampo) and follow the [PostHog SDK releases process](https://posthog.com/handbook/engineering/sdks/releases).
+
+## Creating Changesets
+
+When making changes that should be included in the changelog, create a changeset:
+
+```bash
+# Install sampo CLI (requires Rust toolchain)
+cargo install sampo
+
+# Create a changeset describing your change
+sampo add
+```
+
+Follow the prompts to specify:
+
+- The type of change (`patch`, `minor`, or `major`)
+- A description of the change for the changelog
+
+Changesets are stored in `.sampo/changesets/` and will be consumed during the release process.
+
+## How to trigger a release
+
+1. **Add a changeset** to your PR describing the changes (see above)
+2. **Add the `release` label** to the PR when it's ready for release
+3. **Merge the PR** into `main`
+
+Once merged, the release workflow will automatically:
+
+- Consume all pending changesets
+- Update the version in `mix.exs`
+- Update `CHANGELOG.md` with the new entries
+- Create a Git tag (e.g., `v2.2.0`)
+- Create a GitHub Release with generated notes
+- Publish the package to [Hex.pm](https://hex.pm/packages/posthog)
+
+## Release approval
+
+All releases require approval from the Client Libraries team via the `Release` GitHub environment. Release requests are posted to `#approvals-client-libraries` on Slack.


### PR DESCRIPTION
## :bulb: Motivation and Context
This repo kept changeset and release instructions in `README.md`. Moving them into `RELEASING.md` makes release docs match the other SDK repos and keeps one source of truth.

## :green_heart: How did you test it?
- Re-read `README.md` to confirm it now points to `RELEASING.md`
- Re-read `RELEASING.md` to confirm the full changeset and release flow was preserved
- Updated the PR template comment to point at `RELEASING.md`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
- [ ] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
