### PR TITLE
feat: add Plug tracing header context

### DIFF
--- a/.sampo/changesets/plug-tracing-headers.md
+++ b/.sampo/changesets/plug-tracing-headers.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: minor
+---
+
+Populate Plug request context from PostHog tracing headers.

--- a/lib/posthog/integrations/plug.ex
+++ b/lib/posthog/integrations/plug.ex
@@ -31,6 +31,14 @@ defmodule PostHog.Integrations.Plug do
     conn
   end
 
+  @tracing_headers [
+    {"x-posthog-distinct-id", :distinct_id},
+    {"x-posthog-session-id", :"$session_id"},
+    {"x-posthog-window-id", :"$window_id"}
+  ]
+  @max_header_value_length 1000
+  @control_chars_regex ~r/[\x{00}-\x{1F}\x{7F}-\x{9F}]/u
+
   @doc false
   def conn_to_context(conn) when is_struct(conn, Plug.Conn) do
     query_string = if conn.query_string == "", do: nil, else: conn.query_string
@@ -46,9 +54,65 @@ defmodule PostHog.Integrations.Plug do
         |> URI.to_string(),
       "$host": conn.host,
       "$pathname": conn.request_path,
-      "$ip": remote_ip(conn)
+      "$ip": remote_ip(conn),
+      "$request_method": conn.method
     }
+    |> put_if_present(:"$user_agent", first_header_value(conn, "user-agent"))
+    |> Map.merge(tracing_context(conn))
   end
+
+  defp tracing_context(conn) when is_struct(conn, Plug.Conn) do
+    Enum.reduce(@tracing_headers, %{}, fn {header_name, context_key}, context ->
+      put_if_present(context, context_key, header_value(conn, header_name))
+    end)
+  end
+
+  defp header_value(conn, header_name) when is_struct(conn, Plug.Conn) do
+    case req_header_values(conn, header_name) do
+      [value | _] when is_binary(value) -> sanitize_value(value)
+      _ -> nil
+    end
+  end
+
+  defp first_header_value(conn, header_name) when is_struct(conn, Plug.Conn) do
+    case req_header_values(conn, header_name) do
+      [value | _] when is_binary(value) and value != "" -> value
+      _ -> nil
+    end
+  end
+
+  defp req_header_values(conn, header_name) do
+    normalized_header_name = String.downcase(header_name)
+
+    # Avoid compilation warnings for cases where Plug isn't available
+    # credo:disable-for-lines:1
+    case apply(Plug.Conn, :get_req_header, [conn, normalized_header_name]) do
+      [] ->
+        for {key, value} <- conn.req_headers,
+            is_binary(key),
+            String.downcase(key) == normalized_header_name do
+          value
+        end
+
+      values ->
+        values
+    end
+  end
+
+  defp sanitize_value(value) when is_binary(value) do
+    value =
+      value
+      |> String.replace(@control_chars_regex, "")
+      |> String.trim()
+      |> String.slice(0, @max_header_value_length)
+
+    if value == "", do: nil, else: value
+  end
+
+  defp sanitize_value(_value), do: nil
+
+  defp put_if_present(map, _key, nil), do: map
+  defp put_if_present(map, key, value), do: Map.put(map, key, value)
 
   defp remote_ip(conn) when is_struct(conn, Plug.Conn) do
     # Avoid compilation warnings for cases where Plug isn't available

--- a/lib/posthog/integrations/plug.ex
+++ b/lib/posthog/integrations/plug.ex
@@ -33,8 +33,7 @@ defmodule PostHog.Integrations.Plug do
 
   @tracing_headers [
     {"x-posthog-distinct-id", :distinct_id},
-    {"x-posthog-session-id", :"$session_id"},
-    {"x-posthog-window-id", :"$window_id"}
+    {"x-posthog-session-id", :"$session_id"}
   ]
   @max_header_value_length 1000
   @control_chars_regex ~r/[\x{00}-\x{1F}\x{7F}-\x{9F}]/u

--- a/test/posthog/integrations/plug_test.exs
+++ b/test/posthog/integrations/plug_test.exs
@@ -10,6 +10,19 @@ defmodule PostHog.Integrations.PlugTest do
   setup :setup_supervisor
   setup :setup_logger_handler
 
+  @tracing_header_cases [
+    {"x-posthog-distinct-id", :distinct_id},
+    {"x-posthog-session-id", :"$session_id"},
+    {"x-posthog-window-id", :"$window_id"}
+  ]
+
+  @sanitization_cases [
+    {"trims whitespace", "  value-123  ", "value-123"},
+    {"removes C0 and C1 control characters", "\0  user\n-\u0085123\r\t  ", "user-123"},
+    {"omits empty sanitized values", "\n\t", nil},
+    {"truncates long values", String.duplicate("a", 1_001), String.duplicate("a", 1_000)}
+  ]
+
   defmodule MyRouter do
     use Plug.Router
     require Logger
@@ -22,15 +35,158 @@ defmodule PostHog.Integrations.PlugTest do
   end
 
   test "sets relevant context" do
-    conn = Plug.Test.conn(:get, "https://posthog.com/foo?bar=10")
+    conn =
+      :get
+      |> Plug.Test.conn("https://posthog.com/foo?bar=10")
+      |> Plug.Conn.put_req_header("x-posthog-distinct-id", "user-123")
+      |> Plug.Conn.put_req_header("x-posthog-session-id", "session-123")
+      |> Plug.Conn.put_req_header("x-posthog-window-id", "window-123")
+      |> Plug.Conn.put_req_header("user-agent", "Mozilla/5.0")
+
     assert PostHog.Integrations.Plug.call(conn, nil)
 
     assert PostHog.Context.get(:all) == %{
              "$current_url": "https://posthog.com/foo?bar=10",
              "$host": "posthog.com",
              "$ip": "127.0.0.1",
-             "$pathname": "/foo"
+             "$pathname": "/foo",
+             "$request_method": "GET",
+             "$user_agent": "Mozilla/5.0",
+             distinct_id: "user-123",
+             "$session_id": "session-123",
+             "$window_id": "window-123"
            }
+  end
+
+  describe "conn_to_context/1" do
+    for {header_name, context_key} <- @tracing_header_cases do
+      test "extracts #{header_name} into #{inspect(context_key)}" do
+        conn =
+          :get
+          |> Plug.Test.conn("https://posthog.com/foo")
+          |> Plug.Conn.put_req_header(unquote(header_name), "value-123")
+
+        assert PostHog.Integrations.Plug.conn_to_context(conn)[unquote(context_key)] ==
+                 "value-123"
+      end
+    end
+
+    test "extracts tracing headers case-insensitively and request metadata" do
+      conn =
+        :post
+        |> Plug.Test.conn("https://posthog.com/foo?bar=10")
+        |> Map.update!(:req_headers, fn headers ->
+          [
+            {"X-PostHog-Distinct-ID", "user-123"},
+            {"X-PostHog-Session-ID", "session-123"},
+            {"X-PostHog-Window-ID", "window-123"},
+            {"User-Agent", "Mozilla/5.0"}
+            | headers
+          ]
+        end)
+
+      assert PostHog.Integrations.Plug.conn_to_context(conn) == %{
+               "$current_url": "https://posthog.com/foo?bar=10",
+               "$host": "posthog.com",
+               "$ip": "127.0.0.1",
+               "$pathname": "/foo",
+               "$request_method": "POST",
+               "$user_agent": "Mozilla/5.0",
+               distinct_id: "user-123",
+               "$session_id": "session-123",
+               "$window_id": "window-123"
+             }
+    end
+
+    test "omits missing tracing headers and user agent" do
+      conn = Plug.Test.conn(:get, "https://posthog.com/foo")
+
+      assert PostHog.Integrations.Plug.conn_to_context(conn) == %{
+               "$current_url": "https://posthog.com/foo",
+               "$host": "posthog.com",
+               "$ip": "127.0.0.1",
+               "$pathname": "/foo",
+               "$request_method": "GET"
+             }
+    end
+
+    for {label, raw_value, expected_value} <- @sanitization_cases do
+      test "sanitizes tracing header values: #{label}" do
+        conn =
+          :get
+          |> Plug.Test.conn("https://posthog.com/foo")
+          |> Plug.Conn.put_req_header("x-posthog-distinct-id", unquote(raw_value))
+
+        context = PostHog.Integrations.Plug.conn_to_context(conn)
+
+        if is_nil(unquote(expected_value)) do
+          refute Map.has_key?(context, :distinct_id)
+        else
+          assert context.distinct_id == unquote(expected_value)
+        end
+      end
+    end
+
+    test "keeps user agent value unchanged" do
+      user_agent = "\0  Mozilla/5.0\n  "
+
+      conn =
+        :get
+        |> Plug.Test.conn("https://posthog.com/foo")
+        |> Plug.Conn.put_req_header("user-agent", user_agent)
+
+      assert PostHog.Integrations.Plug.conn_to_context(conn)[:"$user_agent"] == user_agent
+    end
+
+    test "keeps request method unchanged" do
+      conn = Plug.Test.conn("\0  weird\n  ", "https://posthog.com/foo")
+
+      assert PostHog.Integrations.Plug.conn_to_context(conn)[:"$request_method"] == conn.method
+    end
+
+    test "uses the first header value when duplicates are present" do
+      conn =
+        :get
+        |> Plug.Test.conn("https://posthog.com/foo")
+        |> Map.put(:req_headers, [
+          {"x-posthog-window-id", "window-123"},
+          {"x-posthog-window-id", "ignored"}
+        ])
+
+      assert PostHog.Integrations.Plug.conn_to_context(conn)[:"$window_id"] == "window-123"
+    end
+  end
+
+  test "explicit capture properties override context from headers" do
+    conn =
+      :post
+      |> Plug.Test.conn("https://posthog.com/foo")
+      |> Plug.Conn.put_req_header("x-posthog-distinct-id", "header-user")
+      |> Plug.Conn.put_req_header("x-posthog-session-id", "header-session")
+      |> Plug.Conn.put_req_header("x-posthog-window-id", "header-window")
+      |> Plug.Conn.put_req_header("user-agent", "Header Agent")
+
+    PostHog.Integrations.Plug.call(conn, nil)
+
+    PostHog.capture(@supervisor_name, "case tested", %{
+      distinct_id: "explicit-user",
+      "$session_id": "explicit-session",
+      "$window_id": "explicit-window",
+      "$request_method": "EXPLICIT",
+      "$user_agent": "Explicit Agent"
+    })
+
+    assert [event] = all_captured(@supervisor_name)
+
+    assert %{
+             distinct_id: "explicit-user",
+             properties: %{
+               "$session_id": "explicit-session",
+               "$window_id": "explicit-window",
+               "$request_method": "EXPLICIT",
+               "$user_agent": "Explicit Agent"
+             }
+           } = event
   end
 
   setup do
@@ -40,6 +196,32 @@ defmodule PostHog.Integrations.PlugTest do
   end
 
   describe "Bandit" do
+    test "tracing context is attached to exceptions", %{handler_ref: ref} do
+      plug_error_with_headers(:exception, Bandit, MyRouter, [
+        {"x-posthog-distinct-id", "exception-user"},
+        {"x-posthog-session-id", "exception-session"},
+        {"x-posthog-window-id", "exception-window"},
+        {"user-agent", "Exception Agent"}
+      ])
+
+      LoggerHandlerKit.Assert.assert_logged(ref)
+      LoggerHandlerKit.Assert.assert_logged(ref)
+
+      assert [event] = all_captured(@supervisor_name)
+
+      assert %{
+               event: "$exception",
+               distinct_id: "exception-user",
+               properties: %{
+                 distinct_id: "exception-user",
+                 "$session_id": "exception-session",
+                 "$window_id": "exception-window",
+                 "$request_method": "GET",
+                 "$user_agent": "Exception Agent"
+               }
+             } = event
+    end
+
     test "context is attached to exceptions", %{handler_ref: ref} do
       LoggerHandlerKit.Act.plug_error(:exception, Bandit, MyRouter)
       LoggerHandlerKit.Assert.assert_logged(ref)
@@ -364,5 +546,16 @@ defmodule PostHog.Integrations.PlugTest do
                } = properties
       end
     end
+  end
+
+  defp plug_error_with_headers(flavour, web_server, router_plug, headers) do
+    ExUnit.Callbacks.start_supervised!(
+      {web_server, [plug: {router_plug, %{test_pid: self()}}, scheme: :http, port: 8001]}
+    )
+
+    {:ok, conn} = Mint.HTTP.connect(:http, "localhost", 8001)
+    {:ok, _conn, _request_ref} = Mint.HTTP.request(conn, "GET", "/#{flavour}", headers, nil)
+
+    :ok
   end
 end

--- a/test/posthog/integrations/plug_test.exs
+++ b/test/posthog/integrations/plug_test.exs
@@ -12,8 +12,7 @@ defmodule PostHog.Integrations.PlugTest do
 
   @tracing_header_cases [
     {"x-posthog-distinct-id", :distinct_id},
-    {"x-posthog-session-id", :"$session_id"},
-    {"x-posthog-window-id", :"$window_id"}
+    {"x-posthog-session-id", :"$session_id"}
   ]
 
   @sanitization_cases [
@@ -40,7 +39,6 @@ defmodule PostHog.Integrations.PlugTest do
       |> Plug.Test.conn("https://posthog.com/foo?bar=10")
       |> Plug.Conn.put_req_header("x-posthog-distinct-id", "user-123")
       |> Plug.Conn.put_req_header("x-posthog-session-id", "session-123")
-      |> Plug.Conn.put_req_header("x-posthog-window-id", "window-123")
       |> Plug.Conn.put_req_header("user-agent", "Mozilla/5.0")
 
     assert PostHog.Integrations.Plug.call(conn, nil)
@@ -53,8 +51,7 @@ defmodule PostHog.Integrations.PlugTest do
              "$request_method": "GET",
              "$user_agent": "Mozilla/5.0",
              distinct_id: "user-123",
-             "$session_id": "session-123",
-             "$window_id": "window-123"
+             "$session_id": "session-123"
            }
   end
 
@@ -79,7 +76,6 @@ defmodule PostHog.Integrations.PlugTest do
           [
             {"X-PostHog-Distinct-ID", "user-123"},
             {"X-PostHog-Session-ID", "session-123"},
-            {"X-PostHog-Window-ID", "window-123"},
             {"User-Agent", "Mozilla/5.0"}
             | headers
           ]
@@ -93,8 +89,7 @@ defmodule PostHog.Integrations.PlugTest do
                "$request_method": "POST",
                "$user_agent": "Mozilla/5.0",
                distinct_id: "user-123",
-               "$session_id": "session-123",
-               "$window_id": "window-123"
+               "$session_id": "session-123"
              }
     end
 
@@ -149,11 +144,11 @@ defmodule PostHog.Integrations.PlugTest do
         :get
         |> Plug.Test.conn("https://posthog.com/foo")
         |> Map.put(:req_headers, [
-          {"x-posthog-window-id", "window-123"},
-          {"x-posthog-window-id", "ignored"}
+          {"x-posthog-session-id", "session-123"},
+          {"x-posthog-session-id", "ignored"}
         ])
 
-      assert PostHog.Integrations.Plug.conn_to_context(conn)[:"$window_id"] == "window-123"
+      assert PostHog.Integrations.Plug.conn_to_context(conn)[:"$session_id"] == "session-123"
     end
   end
 
@@ -163,7 +158,6 @@ defmodule PostHog.Integrations.PlugTest do
       |> Plug.Test.conn("https://posthog.com/foo")
       |> Plug.Conn.put_req_header("x-posthog-distinct-id", "header-user")
       |> Plug.Conn.put_req_header("x-posthog-session-id", "header-session")
-      |> Plug.Conn.put_req_header("x-posthog-window-id", "header-window")
       |> Plug.Conn.put_req_header("user-agent", "Header Agent")
 
     PostHog.Integrations.Plug.call(conn, nil)
@@ -171,7 +165,6 @@ defmodule PostHog.Integrations.PlugTest do
     PostHog.capture(@supervisor_name, "case tested", %{
       distinct_id: "explicit-user",
       "$session_id": "explicit-session",
-      "$window_id": "explicit-window",
       "$request_method": "EXPLICIT",
       "$user_agent": "Explicit Agent"
     })
@@ -182,7 +175,6 @@ defmodule PostHog.Integrations.PlugTest do
              distinct_id: "explicit-user",
              properties: %{
                "$session_id": "explicit-session",
-               "$window_id": "explicit-window",
                "$request_method": "EXPLICIT",
                "$user_agent": "Explicit Agent"
              }
@@ -200,7 +192,6 @@ defmodule PostHog.Integrations.PlugTest do
       plug_error_with_headers(:exception, Bandit, MyRouter, [
         {"x-posthog-distinct-id", "exception-user"},
         {"x-posthog-session-id", "exception-session"},
-        {"x-posthog-window-id", "exception-window"},
         {"user-agent", "Exception Agent"}
       ])
 
@@ -215,7 +206,6 @@ defmodule PostHog.Integrations.PlugTest do
                properties: %{
                  distinct_id: "exception-user",
                  "$session_id": "exception-session",
-                 "$window_id": "exception-window",
                  "$request_method": "GET",
                  "$user_agent": "Exception Agent"
                }


### PR DESCRIPTION
## :bulb: Motivation and Context

Propagate PostHog browser tracing context through the Elixir Plug integration so backend events and exception captures can be associated with the frontend distinct ID and session.

## :green_heart: How did you test it?

- `mix test test/posthog/integrations/plug_test.exs`
- `mix test`
- Manual temporary ExUnit check for tracing headers flowing into normal capture and Bandit exception capture

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
- [x] Added the `release` label to the PR

<!-- For more details check RELEASING.md -->
