### PR TITLE
feat(flags): implement SDK compliance adapter for posthog-elixir

### DIFF
--- a/sdk_compliance_adapter/README.md
+++ b/sdk_compliance_adapter/README.md
@@ -23,12 +23,19 @@ The adapter is a standalone Elixir application that:
 
 ### Endpoints
 
-- `GET /health` - Health check, returns SDK name/version
+- `GET /health` - Health check, returns SDK name/version and supported capabilities
 - `POST /init` - Initialize SDK with configuration
 - `POST /capture` - Capture a single event
 - `POST /flush` - Flush pending events
+- `POST /get_feature_flag` - Evaluate a feature flag against the `/flags` API
 - `GET /state` - Get internal state for test assertions
 - `POST /reset` - Reset SDK state
+
+### Capabilities
+
+The adapter declares `capture_v0` and `encoding_gzip` capabilities, which gates
+the test suites the harness will run. The `feature_flags` suite has no
+capability requirement and runs unconditionally.
 
 ## Documentation
 

--- a/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
+++ b/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
@@ -119,6 +119,58 @@ defmodule SdkComplianceAdapter.Router do
     json_response(conn, 200, response)
   end
 
+  # POST /get_feature_flag - Evaluate a feature flag
+  post "/get_feature_flag" do
+    params = conn.body_params
+
+    key = params["key"]
+    distinct_id = params["distinct_id"]
+
+    cond do
+      is_nil(key) ->
+        json_response(conn, 400, %{success: false, error: "Missing key"})
+
+      is_nil(distinct_id) ->
+        json_response(conn, 400, %{success: false, error: "Missing distinct_id"})
+
+      true ->
+        # Build the /flags request body. The PostHog Elixir SDK forwards the
+        # body to the /flags endpoint as-is (api_key is auto-injected by the
+        # API client). The harness asserts on the actual /flags HTTP request,
+        # so we mirror person_properties.distinct_id here per the contract:
+        # "auto-added distinct_id in person_properties".
+        person_properties =
+          (params["person_properties"] || %{})
+          |> Map.put("distinct_id", distinct_id)
+
+        body =
+          %{
+            distinct_id: distinct_id,
+            person_properties: person_properties,
+            groups: params["groups"] || %{},
+            group_properties: params["group_properties"] || %{},
+            flag_keys_to_evaluate: [key]
+          }
+          |> maybe_put(:geoip_disable, params["disable_geoip"])
+
+        case PostHog.FeatureFlags.flags(SdkComplianceAdapter.PostHog, body) do
+          {:ok, %{status: 200, body: %{"flags" => flags}}} ->
+            value = extract_flag_value(flags, key)
+            json_response(conn, 200, %{success: true, value: value})
+
+          {:ok, %{status: status, body: resp_body}} ->
+            json_response(conn, 200, %{
+              success: false,
+              error: "Unexpected response status: #{status}",
+              response: inspect(resp_body)
+            })
+
+          {:error, reason} ->
+            json_response(conn, 200, %{success: false, error: inspect(reason)})
+        end
+    end
+  end
+
   # POST /reset - Reset SDK state
   post "/reset" do
     stop_posthog()
@@ -182,6 +234,27 @@ defmodule SdkComplianceAdapter.Router do
         {:error, reason}
     end
   end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp extract_flag_value(flags, key) when is_map(flags) do
+    case Map.get(flags, key) do
+      nil ->
+        nil
+
+      flag_data when is_map(flag_data) ->
+        cond do
+          is_binary(flag_data["variant"]) -> flag_data["variant"]
+          true -> Map.get(flag_data, "enabled", false) == true
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp extract_flag_value(_flags, _key), do: nil
 
   defp stop_posthog do
     case Process.whereis(SdkComplianceAdapter.PostHog) do

--- a/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
+++ b/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
@@ -36,7 +36,8 @@ defmodule SdkComplianceAdapter.Router do
     response = %{
       sdk_name: "posthog-elixir",
       sdk_version: @sdk_version,
-      adapter_version: @adapter_version
+      adapter_version: @adapter_version,
+      capabilities: ["capture_v0", "encoding_gzip"]
     }
 
     json_response(conn, 200, response)


### PR DESCRIPTION
## Summary

Extend the existing `sdk_compliance_adapter/` so the [PostHog SDK Test Harness](https://github.com/PostHog/posthog-sdk-test-harness) can exercise the feature flag and capture suites against `posthog-elixir`.

- Declare the `capture_v0` and `encoding_gzip` capabilities on `/health`. The SDK already supports gzip via the default `Req`-based API client and the existing adapter passes the full capture contract — we just hadn't told the harness about it.
- Add `POST /get_feature_flag`, which constructs the `/flags` body the harness contract expects and forwards it through `PostHog.FeatureFlags.flags/2`.
  - `distinct_id` is mirrored into `person_properties` (the auto-added value the contract asserts on).
  - `groups` and `group_properties` default to empty maps.
  - `flag_keys_to_evaluate` is scoped to the requested key.
  - `geoip_disable` is forwarded when set.
  - `api_key` is auto-injected by the SDK's API client; gzip compression follows the value passed to `/init`.

## Test plan

Locally with `docker compose up --build --abort-on-container-exit` against `ghcr.io/posthog/sdk-test-harness:latest` (digest `sha256:a04e04…`):

```
CAPTURE Tests:        29 passed | 0 failed
FEATURE_FLAGS Tests:   1 passed | 0 failed
Total: 30 | 30 passed | 0 failed
```

The single feature flag test currently in the suite — `request_payload.request_with_person_properties_device_id` — passes, including the `person_properties.distinct_id` auto-add assertion.

## Notes

- The SDK doesn't currently surface the per-event UUID returned from `bare_capture`, so `/capture` still responds with `%{success: true}` only. The harness validates UUIDs via the tracked `requests_made` list (intercepted by `SdkComplianceAdapter.TrackedClient`), so all UUID-related capture tests still pass.
- `force_remote` is accepted but has no effect: the SDK has no local-evaluation path yet, so every `/get_feature_flag` already issues a fresh remote `/flags` request.