### PR TITLE
fix: default api host when omitted

### DIFF
--- a/.sampo/changesets/cantankerous-forgemaster-louhi.md
+++ b/.sampo/changesets/cantankerous-forgemaster-louhi.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Default api_host when omitted

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -1,6 +1,8 @@
 defmodule PostHog.Config do
   require Logger
 
+  @default_api_host "https://us.i.posthog.com"
+
   @shared_schema [
     test_mode: [
       type: :boolean,
@@ -12,7 +14,7 @@ defmodule PostHog.Config do
   @configuration_schema [
                           api_host: [
                             type: :string,
-                            required: true,
+                            default: @default_api_host,
                             doc:
                               "`https://us.i.posthog.com` for US cloud or `https://eu.i.posthog.com` for EU cloud"
                           ],
@@ -107,8 +109,6 @@ defmodule PostHog.Config do
 
   @compiled_configuration_schema NimbleOptions.new!(@configuration_schema)
   @compiled_convenience_schema NimbleOptions.new!(@convenience_schema)
-
-  @default_api_host "https://us.i.posthog.com"
 
   @system_global_properties %{
     "$lib": "posthog-elixir",

--- a/test/posthog/config_test.exs
+++ b/test/posthog/config_test.exs
@@ -25,6 +25,23 @@ defmodule PostHog.ConfigTest do
     assert config.api_host == "https://eu.i.posthog.com"
   end
 
+  test "validate defaults a missing api_host" do
+    expect(PostHog.API.Mock, :client, fn api_key, api_host ->
+      assert api_key == "project_api_key"
+      assert api_host == "https://us.i.posthog.com"
+
+      %PostHog.API.Client{client: :stub_client, module: PostHog.API.Mock}
+    end)
+
+    assert {:ok, config} =
+             PostHog.Config.validate(
+               api_key: "project_api_key",
+               api_client_module: PostHog.API.Mock
+             )
+
+    assert config.api_host == "https://us.i.posthog.com"
+  end
+
   test "validate defaults a blank api_host after trimming whitespace" do
     expect(PostHog.API.Mock, :client, fn api_key, api_host ->
       assert api_key == "project_api_key"


### PR DESCRIPTION
## :bulb: Motivation and Context

`api_host` had a default value internally, but the config schema still required users to provide it. This makes `api_host` optional so SDK initialization can use the default PostHog host when omitted.

## :green_heart: How did you test it?

- [x] `mix test test/posthog/config_test.exs`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file
- [x] Added the `release` label to the PR
