### PR TITLE
chore: trigger releases from main changesets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,5 @@
 ### If releasing new changes
 
 - [ ] Ran `sampo add` to generate a changeset file
-- [ ] Added the `release` label to the PR
 
 <!-- For more details check RELEASING.md -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.sampo/changesets/**'
+      - '.sampo/changesets/*.md'
   workflow_dispatch:
 
 permissions:
@@ -144,7 +144,7 @@ jobs:
             echo "No changes to commit"
             echo "committed=false" >> "$GITHUB_OUTPUT"
           else
-            git commit -m "chore: Release v${NEW_VERSION}"
+            git commit -m "chore: Release v${NEW_VERSION} [skip ci]"
             git push origin main
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,27 @@
 name: "Release"
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
+    paths:
+      - '.sampo/changesets/**'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 # Concurrency control: only one release process can run at a time
-# This prevents race conditions if multiple PRs with 'release' label merge simultaneously
+# This prevents race conditions if multiple releasable changesets merge simultaneously
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  check-release-label:
-    name: Check for release label
+  check-changesets:
+    name: Check for changesets
     runs-on: ubuntu-latest
-    # Run when PR with 'release' label is merged to main
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
-        contains(github.event.pull_request.labels.*.name, 'release'))
     outputs:
-      should-release: ${{ steps.check.outputs.should-release }}
+      has-changesets: ${{ steps.check.outputs.has-changesets }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -34,22 +29,22 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Check release conditions
+      - name: Check for changesets
         id: check
         run: |
           changeset_count=$(find .sampo/changesets -name '*.md' 2>/dev/null | wc -l)
           if [ "$changeset_count" -gt 0 ]; then
-            echo "should-release=true" >> "$GITHUB_OUTPUT"
+            echo "has-changesets=true" >> "$GITHUB_OUTPUT"
             echo "Found $changeset_count changeset(s), ready to release"
           else
-            echo "should-release=false" >> "$GITHUB_OUTPUT"
+            echo "has-changesets=false" >> "$GITHUB_OUTPUT"
             echo "No changesets to release"
           fi
 
   notify-approval-needed:
     name: Notify Slack - Approval Needed
-    needs: check-release-label
-    if: needs.check-release-label.outputs.should-release == 'true'
+    needs: check-changesets
+    if: needs.check-changesets.outputs.has-changesets == 'true'
     uses: posthog/.github/.github/workflows/notify-approval-needed.yml@main
     with:
       slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -60,11 +55,11 @@ jobs:
 
   release:
     name: Release and publish
-    needs: [check-release-label, notify-approval-needed]
+    needs: [check-changesets, notify-approval-needed]
     runs-on: ubuntu-latest
-    # Use `always()` to ensure the job runs even if the check-release-label job fails
+    # Use `always()` to ensure the job runs even if the Slack notification fails
     # but still depend on it to be able to use `needs.notify-approval-needed.outputs.slack_ts`
-    if: always() && needs.check-release-label.outputs.should-release == 'true'
+    if: always() && needs.check-changesets.outputs.has-changesets == 'true'
     environment: "Release" # This will require an approval from a maintainer, they are notified in Slack above
     permissions:
       contents: write
@@ -199,7 +194,7 @@ jobs:
 
   notify-released:
     name: Notify Slack - Released
-    needs: [check-release-label, notify-approval-needed, release]
+    needs: [check-changesets, notify-approval-needed, release]
     runs-on: ubuntu-latest
     if: always() && needs.release.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
     steps:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ This repository uses [Sampo](https://github.com/bruits/sampo) for versioning and
 
 2. Commit the generated `.sampo/changesets/*.md` file with your pull request.
 3. After review, merge the PR to `main`. No GitHub release label is required.
-4. A push to `main` that includes `.sampo/changesets/**` changes automatically starts the release workflow.
+4. A push to `main` that includes `.sampo/changesets/*.md` changes automatically starts the release workflow.
 5. Approve the release when prompted in Slack / the GitHub `Release` environment.
 
 After approval, The workflow runs Sampo, publishes the Hex package, tags the release, and creates a GitHub Release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,41 +1,26 @@
 # Releasing
 
-Releases are semi-automated using [Sampo](https://github.com/PostHog/sampo) and follow the [PostHog SDK releases process](https://posthog.com/handbook/engineering/sdks/releases).
+This repository uses [Sampo](https://github.com/bruits/sampo) for versioning and changelog generation, with GitHub Actions handling publishing.
 
-## Creating Changesets
+## How to Release
 
-When making changes that should be included in the changelog, create a changeset:
+1. When making a change that should be released, include a Sampo changeset:
 
-```bash
-# Install sampo CLI (requires Rust toolchain)
-cargo install sampo
+   ```bash
+   sampo add
+   ```
 
-# Create a changeset describing your change
-sampo add
-```
+2. Commit the generated `.sampo/changesets/*.md` file with your pull request.
+3. After review, merge the PR to `main`. No GitHub release label is required.
+4. A push to `main` that includes `.sampo/changesets/**` changes automatically starts the release workflow.
+5. Approve the release when prompted in Slack / the GitHub `Release` environment.
 
-Follow the prompts to specify:
+After approval, The workflow runs Sampo, publishes the Hex package, tags the release, and creates a GitHub Release.
 
-- The type of change (`patch`, `minor`, or `major`)
-- A description of the change for the changelog
+## Manual Trigger
 
-Changesets are stored in `.sampo/changesets/` and will be consumed during the release process.
+You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending Sampo changesets.
 
-## How to trigger a release
+## Troubleshooting
 
-1. **Add a changeset** to your PR describing the changes (see above)
-2. **Add the `release` label** to the PR when it's ready for release
-3. **Merge the PR** into `main`
-
-Once merged, the release workflow will automatically:
-
-- Consume all pending changesets
-- Update the version in `mix.exs`
-- Update `CHANGELOG.md` with the new entries
-- Create a Git tag (e.g., `v2.2.0`)
-- Create a GitHub Release with generated notes
-- Publish the package to [Hex.pm](https://hex.pm/packages/posthog)
-
-## Release approval
-
-All releases require approval from the Client Libraries team via the `Release` GitHub environment. Release requests are posted to `#approvals-client-libraries` on Slack.
+If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.sampo/changesets/*.md` file.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,26 +1,40 @@
 # Releasing
 
-This repository uses [Sampo](https://github.com/bruits/sampo) for versioning and changelog generation, with GitHub Actions handling publishing.
+Releases are semi-automated using [Sampo](https://github.com/PostHog/sampo) and follow the [PostHog SDK releases process](https://posthog.com/handbook/engineering/sdks/releases).
 
-## How to Release
+## Creating Changesets
 
-1. When making a change that should be released, include a Sampo changeset:
+When making changes that should be included in the changelog, create a changeset:
 
-   ```bash
-   sampo add
-   ```
+```bash
+# Install sampo CLI (requires Rust toolchain)
+cargo install sampo
 
-2. Commit the generated `.sampo/changesets/*.md` file with your pull request.
-3. After review, merge the PR to `main`. No GitHub release label is required.
-4. A push to `main` that includes `.sampo/changesets/*.md` changes automatically starts the release workflow.
-5. Approve the release when prompted in Slack / the GitHub `Release` environment.
+# Create a changeset describing your change
+sampo add
+```
 
-After approval, The workflow runs Sampo, publishes the Hex package, tags the release, and creates a GitHub Release.
+Follow the prompts to specify:
 
-## Manual Trigger
+- The type of change (`patch`, `minor`, or `major`)
+- A description of the change for the changelog
 
-You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending Sampo changesets.
+Changesets are stored in `.sampo/changesets/` and will be consumed during the release process.
 
-## Troubleshooting
+## How to trigger a release
 
-If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.sampo/changesets/*.md` file.
+1. **Add a changeset** to your PR describing the changes (see above)
+2. **Merge the PR** into `main`. No release label is required.
+
+Once merged, the release workflow will automatically:
+
+- Consume all pending changesets
+- Update the version in `mix.exs`
+- Update `CHANGELOG.md` with the new entries
+- Create a Git tag (e.g., `v2.2.0`)
+- Create a GitHub Release with generated notes
+- Publish the package to [Hex.pm](https://hex.pm/packages/posthog)
+
+## Release approval
+
+All releases require approval from the Client Libraries team via the `Release` GitHub environment. Release requests are posted to `#approvals-client-libraries` on Slack.


### PR DESCRIPTION
## :bulb: Motivation and Context
Standardize SDK releases so they are triggered by pushes to `main` containing Sampo changesets, rather than by PR labels or `pull_request.closed` events.

## Changes
- Updated the release workflow to run on `push` to `main` for `.sampo/changesets/*.md`, while keeping manual `workflow_dispatch`
- Removed the release-label check from the release flow
- Added `[skip ci]` to release version-bump commits and narrowed release path filters to changeset markdown files to avoid re-triggering release workflows on consumed changeset deletions
- Updated only the release-label parts of the release docs and PR checklist

## :green_heart: How did you test it?
- Parsed the updated release workflow YAML locally
- Verified the release workflow no longer references `pull_request` or PR labels
- Verified the PR template no longer asks for a release label

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file (not needed for this release-process-only change)
