### PR TITLE
fix: keep flag payload reads out of only_accessed

### DIFF
--- a/.sampo/changesets/silent-payload-access.md
+++ b/.sampo/changesets/silent-payload-access.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Do not count `get_flag_payload/2` calls as accesses for `only_accessed/1`.

--- a/lib/posthog/feature_flags/evaluations.ex
+++ b/lib/posthog/feature_flags/evaluations.ex
@@ -8,16 +8,15 @@ defmodule PostHog.FeatureFlags.Evaluations do
   paying the cost of one round-trip per flag.
 
   Each snapshot owns a small `Agent` linked to the calling process that tracks
-  which flags were accessed via `enabled?/2`, `get_flag/2`, and
-  `get_flag_payload/2`. The Agent exits with the calling process — no manual
-  cleanup is required.
+  which flags were accessed via `enabled?/2` and `get_flag/2`. The Agent exits
+  with the calling process — no manual cleanup is required.
 
   ## Querying
 
   Use `enabled?/2`, `get_flag/2`, and `get_flag_payload/2` to read individual
-  flags. `enabled?/2` and `get_flag/2` fire a `$feature_flag_called` event
-  with full metadata (id, version, reason, request_id) on each call;
-  `get_flag_payload/2` records the access without firing an event.
+  flags. `enabled?/2` and `get_flag/2` record access and fire a
+  `$feature_flag_called` event with full metadata (id, version, reason,
+  request_id) on each call; `get_flag_payload/2` does neither.
 
       {:ok, snapshot} = PostHog.FeatureFlags.evaluate_flags("user-123")
 
@@ -41,9 +40,9 @@ defmodule PostHog.FeatureFlags.Evaluations do
   ## Filtering
 
   Use `only_accessed/1` to narrow a snapshot to flags accessed so far via
-  `enabled?/2`, `get_flag/2`, or `get_flag_payload/2`. Use `only/2` to narrow
-  by an explicit key list. Both return a fresh snapshot with its own access
-  tracker — calls on the filtered view do not back-propagate to the parent.
+  `enabled?/2` or `get_flag/2`. Use `only/2` to narrow by an explicit key list.
+  Both return a fresh snapshot with its own access tracker — calls on the
+  filtered view do not back-propagate to the parent.
 
       narrowed = PostHog.FeatureFlags.Evaluations.only_accessed(snapshot)
       PostHog.FeatureFlags.set_in_context(narrowed)
@@ -157,14 +156,13 @@ defmodule PostHog.FeatureFlags.Evaluations do
 
   @doc """
   Returns the configured payload for the flag, or `nil` for unknown flags or
-  flags without a payload. Records the access.
+  flags without a payload.
 
-  Does **not** fire a `$feature_flag_called` event.
+  Does **not** record access for `only_accessed/1` or fire a
+  `$feature_flag_called` event.
   """
   @spec get_flag_payload(t(), String.t()) :: any() | nil
-  def get_flag_payload(%__MODULE__{flags: flags} = snapshot, key) when is_binary(key) do
-    record_access(snapshot, key)
-
+  def get_flag_payload(%__MODULE__{flags: flags}, key) when is_binary(key) do
     case Map.fetch(flags, key) do
       {:ok, %Result{payload: payload}} -> payload
       :error -> nil
@@ -178,8 +176,8 @@ defmodule PostHog.FeatureFlags.Evaluations do
   def keys(%__MODULE__{flags: flags}), do: flags |> Map.keys() |> Enum.sort()
 
   @doc """
-  Returns the sorted list of keys accessed via `enabled?/2`, `get_flag/2`, or
-  `get_flag_payload/2` on this snapshot.
+  Returns the sorted list of keys accessed via `enabled?/2` or `get_flag/2` on
+  this snapshot.
 
   Includes keys that were accessed but absent from the snapshot.
   """
@@ -190,7 +188,7 @@ defmodule PostHog.FeatureFlags.Evaluations do
 
   @doc """
   Returns a copy of the snapshot scoped to the flags accessed so far via
-  `enabled?/2`, `get_flag/2`, or `get_flag_payload/2`.
+  `enabled?/2` or `get_flag/2`.
 
   Returns an empty snapshot when nothing has been accessed yet — including
   no flags would be more surprising than helpful, since the caller asked for

--- a/test/posthog/feature_flags/evaluations_test.exs
+++ b/test/posthog/feature_flags/evaluations_test.exs
@@ -10,7 +10,6 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
   alias PostHog.API
   alias PostHog.FeatureFlags
   alias PostHog.FeatureFlags.Evaluations
-  alias PostHog.FeatureFlags.Result
 
   setup :setup_supervisor
   setup :verify_on_exit!
@@ -250,11 +249,12 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
       assert Evaluations.get_flag_payload(snapshot, "unknown-flag") == nil
     end
 
-    test "does not fire a $feature_flag_called event", %{snapshot: snapshot} do
+    test "does not fire a $feature_flag_called event or count as access", %{snapshot: snapshot} do
       Evaluations.get_flag_payload(snapshot, "variant-flag")
       Evaluations.get_flag_payload(snapshot, "unknown-flag")
 
       assert all_captured() == []
+      assert Evaluations.accessed(snapshot) == []
     end
   end
 
@@ -280,10 +280,10 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
       assert Evaluations.keys(narrowed) == ["variant-flag"]
     end
 
-    test "narrows the snapshot to flags accessed via get_flag_payload/2", %{snapshot: snapshot} do
+    test "does not include flags read only via get_flag_payload/2", %{snapshot: snapshot} do
       Evaluations.get_flag_payload(snapshot, "variant-flag")
       narrowed = Evaluations.only_accessed(snapshot)
-      assert Evaluations.keys(narrowed) == ["variant-flag"]
+      assert Evaluations.keys(narrowed) == []
     end
 
     test "returns an empty snapshot when nothing has been accessed", %{snapshot: snapshot} do


### PR DESCRIPTION
## :bulb: Motivation and Context

`get_flag_payload/2` should be a silent payload lookup. Other server-side SDKs (Python/Node/PHP) document and implement payload reads as not counting for `only_accessed`, but the Elixir SDK was recording those reads as accesses. That meant `only_accessed/1` could attach flags that code only fetched payloads for, not flags it branched on.

This aligns Elixir with the server-side SDK behavior by keeping `get_flag_payload/2` out of the accessed set.

## :green_heart: How did you test it?

- `mix format`
- `mix test`
- `mix credo --strict`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
  - Added `.sampo/changesets/silent-payload-access.md` manually because the `sampo` CLI is not installed locally.

<!-- For more details check RELEASING.md -->
