### PR TITLE
Add `mode` configuration option

### DIFF
--- a/.sampo/changesets/sullen-baron-ahti.md
+++ b/.sampo/changesets/sullen-baron-ahti.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: minor
+---
+
+Add new `mode` configuration option. Set it to `drop_events` to not send events to the server (useful in dev). `test_mode: true` is deprecated, use `mode: :test` instead.

--- a/README.md
+++ b/README.md
@@ -37,11 +37,20 @@ config :posthog,
   in_app_otp_apps: [:my_app]
 ```
 
-For test environment, you want to enable test_mode:
+For test environment, you want to enable test mode:
 
 ```elixir
+# config/test.exs
 config :posthog,
-  test_mode: true
+  mode: :test
+```
+
+If you don't want to send events in `dev`, you can enable drop_events mode:
+
+```elixir
+# config/dev.exs
+config :posthog,
+  mode: :drop_events
 ```
 
 Optionally, enable [Plug integration](lib/posthog/integrations/plug.ex).

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,5 @@
 import Config
 
-config :posthog, enable: false, test_mode: true
+config :posthog, enable: false, mode: :test
 
 if File.exists?("config/integration.exs"), do: import_config("integration.exs")

--- a/lib/posthog/application.ex
+++ b/lib/posthog/application.ex
@@ -18,7 +18,7 @@ defmodule PostHog.Application do
       end
 
     ownership_children =
-      if conv_config.test_mode do
+      if conv_config.mode == :test || conv_config[:test_mode] do
         [{NimbleOwnership, name: PostHog.Ownership}]
       else
         []

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -6,8 +6,18 @@ defmodule PostHog.Config do
   @shared_schema [
     test_mode: [
       type: :boolean,
-      default: false,
-      doc: "Test mode allows tests assert captured events."
+      doc: "Test mode allows tests assert captured events.",
+      deprecated: "Use `mode: :test` instead."
+    ],
+    mode: [
+      type: {:in, [:normal, :drop_events, :test]},
+      default: :normal,
+      doc: """
+      Supervisor's mode of operation.
+      * `:normal` (default) - all events are sent to PostHog
+      * `:drop_events` - all events are dropped. This is useful for example in dev environment.
+      * `:test` - all events are captured for assertions. See `PostHog.Test`
+      """
     ]
   ]
 
@@ -156,6 +166,10 @@ defmodule PostHog.Config do
     |> NimbleOptions.validate!(@compiled_convenience_schema)
     |> Map.new()
     |> case do
+      %{enable: true, mode: mode} = conv when mode in [:drop_events, :test] ->
+        config = configuration_options |> Keyword.put_new(:api_key, "fake_key") |> validate!()
+        {conv, config}
+
       %{enable: true} = conv ->
         config = validate!(configuration_options)
         {conv, config}

--- a/lib/posthog/registry.ex
+++ b/lib/posthog/registry.ex
@@ -7,6 +7,23 @@ defmodule PostHog.Registry do
       |> Registry.meta(:config)
 
     config
+  rescue
+    e in ArgumentError ->
+      if supervisor_name == PostHog do
+        {conv_config, _} = PostHog.Config.read!()
+
+        if !conv_config.enable do
+          raise PostHog.Error, """
+          PostHog default supervisor isn't started. Make sure to set `enable: true` configuration option.
+
+          If you're running PostHog supervisor under your own supervision tree, you must specify PostHog supervisor name explicitely, e.g.:
+
+              PostHog.capture(MyPostHog, "event_name", %{distinct_id: "123"})
+          """
+        end
+      end
+
+      raise e
   end
 
   def registry_name(supervisor_name), do: Module.concat(supervisor_name, Registry)

--- a/lib/posthog/sender.ex
+++ b/lib/posthog/sender.ex
@@ -33,6 +33,12 @@ defmodule PostHog.Sender do
       %{test_mode: true} ->
         PostHog.Test.remember_event(supervisor_name, event)
 
+      %{mode: :test} ->
+        PostHog.Test.remember_event(supervisor_name, event)
+
+      %{mode: :drop_events} ->
+        :ok
+
       _ ->
         senders =
           supervisor_name

--- a/lib/posthog/supervisor.ex
+++ b/lib/posthog/supervisor.ex
@@ -64,7 +64,6 @@ defmodule PostHog.Supervisor do
            supervisor_name: config.supervisor_name,
            max_batch_time_ms: Map.get(config, :max_batch_time_ms, :timer.seconds(10)),
            max_batch_events: Map.get(config, :max_batch_events, 100),
-           test_mode: config.test_mode,
            index: index
          ]},
         id: {PostHog.Sender, index}

--- a/lib/posthog/test.ex
+++ b/lib/posthog/test.ex
@@ -2,11 +2,11 @@ defmodule PostHog.Test do
   @moduledoc """
   PostHog Test Utilities Module
 
-  PostHog makes it simple to test captured events. Make sure to set `test_mode` in your `config/test.exs`:
+  PostHog makes it simple to test captured events. Make sure to set `mode: :test` in your `config/test.exs`:
 
   ```
   config :posthog, 
-    test_mode: true
+    mode: test
   ```
 
   Now PostHog will not send your captured events to the server and will instead

--- a/test/posthog/sender_test.exs
+++ b/test/posthog/sender_test.exs
@@ -8,12 +8,11 @@ defmodule PostHog.SenderTest do
 
   @supervisor_name __MODULE__
 
-  setup do
+  setup context do
     registry = PostHog.Registry.registry_name(@supervisor_name)
+    config = Map.merge(%{mode: :normal}, Map.get(context, :config, %{}))
 
-    start_link_supervised!(
-      {Registry, keys: :unique, name: registry, meta: [config: %{test_mode: false}]}
-    )
+    start_link_supervised!({Registry, keys: :unique, name: registry, meta: [config: config]})
 
     %{api_client: %API.Client{client: :fake_client, module: API.Mock}, registry: registry}
   end
@@ -63,6 +62,24 @@ defmodule PostHog.SenderTest do
 
       assert {:messages, ["$gen_cast": {:event, "my_event"}]} =
                Process.info(busy_pid, :messages)
+    end
+
+    @tag config: %{mode: :drop_events}
+    test "drops event in :drop_events mode", %{registry: registry} do
+      pid =
+        start_link_supervised!(
+          Supervisor.child_spec(
+            {Agent, fn -> Registry.register(registry, {PostHog.Sender, 1}, :available) end},
+            id: Agent1
+          )
+        )
+
+      :sys.suspend(pid)
+
+      assert :ok = Sender.send("my_event", @supervisor_name)
+
+      assert {:messages, []} =
+               Process.info(pid, :messages)
     end
   end
 

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -159,6 +159,20 @@ defmodule PostHogTest do
                event.uuid
              )
     end
+
+    @tag config: [supervisor_name: MyPostHog, mode: :drop_events]
+    test "drop_events mode drops events" do
+      PostHog.bare_capture(MyPostHog, "case tested", "distinct_id")
+
+      assert [] = all_captured(MyPostHog)
+    end
+
+    @tag config: [supervisor_name: MyPostHog, test_mode: true, mode: :drop_events]
+    test "deprecated test_mode: true still works" do
+      PostHog.bare_capture(MyPostHog, "case tested", "distinct_id")
+
+      assert [_] = all_captured(MyPostHog)
+    end
   end
 
   describe "capture/4" do

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -16,8 +16,21 @@ defmodule PostHogTest do
     end
 
     @tag config: [supervisor_name: CustomPostHog]
+    test "meaningful error if application isn't started" do
+      assert_raise PostHog.Error, fn ->
+        PostHog.config()
+      end
+    end
+
+    @tag config: [supervisor_name: CustomPostHog]
     test "uses custom supervisor name" do
       assert %{supervisor_name: CustomPostHog} = PostHog.config(CustomPostHog)
+    end
+
+    test "pass real error as is for custom supervisors" do
+      assert_raise ArgumentError,
+                   "unknown registry: CustomPostHog.Registry. Either the registry name is invalid or the registry is not running, possibly because its application isn't started",
+                   fn -> PostHog.config(CustomPostHog) end
     end
   end
 
@@ -227,6 +240,13 @@ defmodule PostHogTest do
                },
                timestamp: _
              } = event
+    end
+
+    @tag config: [supervisor_name: CustomPostHog]
+    test "meaningful error if application isn't started" do
+      assert_raise PostHog.Error, fn ->
+        PostHog.capture("case tested", %{distinct_id: "distinct_id"})
+      end
     end
   end
 

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -19,7 +19,7 @@ defmodule PostHog.Case do
         api_client_module: PostHog.API.Mock,
         supervisor_name: context[:test],
         capture_level: :info,
-        test_mode: true
+        mode: :test
       ]
       |> Keyword.merge(context[:config] || [])
       |> PostHog.Config.validate!()


### PR DESCRIPTION
## :bulb: Motivation and Context
Should address https://github.com/PostHog/posthog-elixir/issues/81 (see [comment](https://github.com/PostHog/posthog-elixir/issues/81#issuecomment-3906509110))

Changes:
1. Improve error for cases when user set `enable: false` in configuration but still tried to use default PostHog instance.
2. Introduce new configuration options `mode :: :normal | :drop_events | :test`. `normal` mode is, well, normal. `test` mode is basically current `test_mode: true` (and thus `test_mode` option is deprecated). `drop_events` simply drops all events instead of sending them to PostHog.


## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
