### PR TITLE
Normalize Elixir anonymous function stack frames

### DIFF
--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -215,7 +215,7 @@ defmodule PostHog.Handler do
         %{
           platform: "custom",
           lang: "elixir",
-          function: Exception.format_mfa(module, function, arity_or_args),
+          function: format_function(module, function, arity_or_args),
           filename: filename,
           lineno: lineno,
           module: inspect(module),
@@ -229,6 +229,16 @@ defmodule PostHog.Handler do
       type: "raw",
       frames: frames
     }
+  end
+
+  defp format_function(module, function, arity_or_args) do
+    module
+    |> Exception.format_mfa(function, arity_or_args)
+    |> normalize_anonymous_function()
+  end
+
+  defp normalize_anonymous_function(function) do
+    String.replace(function, ~r/anonymous fn\(\d+\) in /, "anonymous fn in ")
   end
 
   defp maybe_add_source_context(frame, filename, lineno, config) do

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -119,6 +119,33 @@ defmodule PostHog.HandlerTest do
     end
   end
 
+  for index <- [0, 1, 9, 99, 250] do
+    test "normalizes volatile anonymous function index #{index} in stack frames", %{
+      handler_ref: ref,
+      config: %{supervisor_name: supervisor_name}
+    } do
+      stacktrace = [
+        {__MODULE__, unquote(:"anonymous fn(#{index}) in PostHog.HandlerTest.example/1"), 1,
+         [file: ~c"test/posthog/handler_test.exs", line: 1]}
+      ]
+
+      Logger.error("Hello World", crash_reason: {%RuntimeError{message: "boom"}, stacktrace})
+      LoggerHandlerKit.Assert.assert_logged(ref)
+
+      assert [event] = all_captured(supervisor_name)
+      assert %{properties: %{"$exception_list": exception_list}} = event
+
+      assert exception_list
+             |> Enum.flat_map(fn exception ->
+               get_in(exception, [:stacktrace, :frames]) || []
+             end)
+             |> Enum.any?(fn frame ->
+               frame.function ==
+                 ~s(PostHog.HandlerTest."anonymous fn in PostHog.HandlerTest.example/1"/1)
+             end)
+    end
+  end
+
   test "string message", %{handler_ref: ref, config: %{supervisor_name: supervisor_name}} do
     LoggerHandlerKit.Act.string_message()
     LoggerHandlerKit.Assert.assert_logged(ref)


### PR DESCRIPTION
## Summary
- Normalize volatile Elixir anonymous function indexes in error tracking stack frame names
- Prevent equivalent anonymous function crashes from fragmenting into separate issues when indexes differ across compiled/runtime frames
- Add regression coverage for normalized stack frame output

## Tests
- mix test test/posthog/handler_test.exs
- mix test
- mix credo --strict

## Disclaimer: generated with Codex ;)