### PR TITLE
chore: Document public APIs in ExDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,90 +113,88 @@ You can always inspect the context:
 iex> PostHog.get_context()
 %{distinct_id: "distinct_id_of_the_user"}
 iex> PostHog.get_event_context("sensitive_event")
-%{distinct_id: "distinct_id_of_the_user", "$process_person_profile": true}
+%{distinct_id: "distinct_id_of_the_user", "$process_person_profile": false}
 ```
 
 ## Feature Flags
 
-`PostHog.FeatureFlags.check/2` is the main function for checking a feature flag.
+Evaluate feature flags once for a user with `PostHog.FeatureFlags.evaluate_flags/1`,
+then read values from the returned snapshot.
 
 ```elixir
-# Simple boolean feature flag
-iex> PostHog.FeatureFlags.check("example-feature-flag-1", "user123")
-{:ok, true}
+# Boolean feature flag
+{:ok, snapshot} = PostHog.FeatureFlags.evaluate_flags("user123")
+if PostHog.FeatureFlags.Evaluations.enabled?(snapshot, "new-dashboard") do
+  # Do something differently for this user
+end
 
-# Note how it automatically sets `$feature/example-feature-flag-1` property in the context
-iex> PostHog.get_context()
-%{"$feature/example-feature-flag-1" => true}
+# Multivariate feature flag
+case PostHog.FeatureFlags.Evaluations.get_flag(snapshot, "checkout-flow") do
+  "variant-a" -> :variant_a
+  true -> :enabled_boolean_flag
+  false -> :disabled
+  nil -> :not_returned
+end
 
-# It will attempt to take distinct_id from the context if it's not provided
-iex> PostHog.set_context(%{distinct_id: "user123"})
-:ok
-iex> PostHog.FeatureFlags.check("example-feature-flag-1")
-{:ok, true}
-
-# You can also pass a map with body parameters that will be sent to the /flags API as-is
-iex> PostHog.FeatureFlags.check("example-feature-flag-1", %{distinct_id: "user123", groups: %{group_type: "group_id"}})
-{:ok, true}
-
-# It returns variant if it's set
-iex> PostHog.FeatureFlags.check("example-feature-flag-2", "user123")
-{:ok, "variant2"}
-
-# Returns error if feature flag doesn't exist
-iex> PostHog.FeatureFlags.check("example-feature-flag-3", "user123")
-{:error, %PostHog.UnexpectedResponseError{message: "Feature flag example-feature-flag-3 was not found in the response", response: ...}}
+# Optional payload
+payload = PostHog.FeatureFlags.Evaluations.get_flag_payload(snapshot, "checkout-flow")
 ```
 
-If you're feeling adventurous and/or simply writing a script, you can use the `PostHog.FeatureFlags.check!/2` helper instead and it will return a boolean or raise an error.
+`get_flag/2` returns the variant string for multivariate flags, `true` for enabled
+boolean flags, `false` for disabled flags, and `nil` when the flag was not returned
+by the evaluation.
+
+### Include feature flag information when capturing events
+
+If you want to break down or filter captured events by feature flag value, put the
+same snapshot in the process context before capturing events:
 
 ```elixir
-# Simple boolean feature flag
-iex> PostHog.FeatureFlags.check!("example-feature-flag-1", "user123")
-true
+{:ok, snapshot} = PostHog.FeatureFlags.evaluate_flags("user123")
 
-# Works for variants too
-iex> PostHog.FeatureFlags.check!("example-feature-flag-2", "user123")
-"variant2"
+if PostHog.FeatureFlags.Evaluations.enabled?(snapshot, "new-dashboard") do
+  # Do something differently for this user
+end
 
-# Raises error if feature flag doesn't exist
-iex> PostHog.FeatureFlags.check!("example-feature-flag-3", "user123")
-** (PostHog.UnexpectedResponseError) Feature flag example-feature-flag-3 was not found in the response
+PostHog.FeatureFlags.set_in_context(snapshot)
+PostHog.capture("page_viewed", %{distinct_id: "user123"})
 ```
 
-### Getting the Full Flag Result
-
-If you need more than just the value -- for example, the payload configured for a
-flag or variant -- use `PostHog.FeatureFlags.get_feature_flag_result/2`:
+This attaches `$feature/<flag-key>` properties and `$active_feature_flags` without
+making another `/flags` request. To reduce event property bloat, filter the
+snapshot first:
 
 ```elixir
-iex> PostHog.FeatureFlags.get_feature_flag_result("my-flag", "user123")
-{:ok, %PostHog.FeatureFlags.Result{key: "my-flag", enabled: true, variant: nil, payload: nil}}
+# Attach only flags accessed with enabled?/2 or get_flag/2
+PostHog.FeatureFlags.set_in_context(
+  PostHog.FeatureFlags.Evaluations.only_accessed(snapshot)
+)
 
-# Multivariant flag with a JSON payload
-iex> PostHog.FeatureFlags.get_feature_flag_result("my-experiment", "user123")
-{:ok, %PostHog.FeatureFlags.Result{key: "my-experiment", enabled: true, variant: "control", payload: %{"button_color" => "blue"}}}
-
-# Flag not found
-iex> PostHog.FeatureFlags.get_feature_flag_result("non-existent-flag", "user123")
-{:ok, nil}
+# Or attach only specific flags
+PostHog.FeatureFlags.set_in_context(
+  PostHog.FeatureFlags.Evaluations.only(snapshot, ["checkout-flow", "new-dashboard"])
+)
 ```
 
-By default this sends a `$feature_flag_called` event, which PostHog uses to
-track feature flag usage in your analytics, and to measure experiment exposure
-when the flag is linked to an A/B test. You can opt out with `send_event: false`:
+### Evaluating only specific flags
+
+By default, `evaluate_flags/1` evaluates every flag for the user. If you only need
+a few flags, pass `:flag_keys` to request only those flags:
 
 ```elixir
-iex> PostHog.FeatureFlags.get_feature_flag_result("my-flag", "user123", send_event: false)
-{:ok, %PostHog.FeatureFlags.Result{key: "my-flag", enabled: true, variant: nil, payload: nil}}
+{:ok, snapshot} =
+  PostHog.FeatureFlags.evaluate_flags(%{
+    distinct_id: "user123",
+    flag_keys: ["checkout-flow", "new-dashboard"]
+  })
 ```
 
-A bang variant is also available:
-
-```elixir
-iex> PostHog.FeatureFlags.get_feature_flag_result!("my-flag", "user123")
-%PostHog.FeatureFlags.Result{key: "my-flag", enabled: true, variant: nil, payload: nil}
-```
+> #### Deprecated feature flag helpers {: .warning}
+>
+> `PostHog.FeatureFlags.check/2`, `PostHog.FeatureFlags.check!/2`,
+> `PostHog.FeatureFlags.get_feature_flag_result/2`, and
+> `PostHog.FeatureFlags.get_feature_flag_result!/2` still work during the
+> migration period, but prefer `evaluate_flags/1` for new code.
 
 ## Error Tracking
 

--- a/lib/posthog.ex
+++ b/lib/posthog.ex
@@ -9,7 +9,7 @@ defmodule PostHog do
   @typedoc ~S(Event name, such as `"user_signed_up"` or `"$create_alias"`)
   @type event() :: String.t()
 
-  @typedoc "string representing distinct ID"
+  @typedoc "String representing a PostHog distinct ID."
   @type distinct_id() :: String.t()
 
   @typedoc """
@@ -194,6 +194,7 @@ defmodule PostHog do
       > PostHog.get_event_context(MyPostHog, "$exception")
       %{foo: "bar"}
   """
-  @spec get_event_context(supervisor_name()) :: properties()
+  @spec get_event_context(event()) :: properties()
+  @spec get_event_context(supervisor_name(), event()) :: properties()
   def get_event_context(name \\ __MODULE__, event), do: PostHog.Context.get(name, event)
 end

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -98,16 +98,31 @@ defmodule PostHog.API.Client do
 
   defstruct [:client, :module]
 
+  @typedoc """
+  Wrapper returned by `c:client/2` and stored in `t:PostHog.Config.config/0`.
+
+  - `:client` - opaque client state passed back to `c:request/4`.
+  - `:module` - module implementing this behaviour.
+  """
   @type t() :: %__MODULE__{
           client: client(),
           module: atom()
         }
+
   @typedoc """
   Arbitrary term that is passed as the first argument to the `c:request/4` callback.
 
   For the default client, this is a `t:Req.Request.t/0` struct.
   """
   @type client() :: any()
+
+  @typedoc """
+  Response tuple returned by `c:request/4`.
+
+  Successful responses must expose at least a numeric `:status` and decoded
+  `:body`; errors should return the exception or error struct from the HTTP
+  client.
+  """
   @type response() :: {:ok, %{status: non_neg_integer(), body: any()}} | {:error, Exception.t()}
 
   @doc """
@@ -123,7 +138,22 @@ defmodule PostHog.API.Client do
   @callback request(client :: client(), method :: atom(), url :: String.t(), opts :: keyword()) ::
               response()
 
+  @doc """
+  Creates the default Req-backed PostHog API client.
+
+  ## Parameters
+
+  - `api_key` - PostHog project API key. It is stored privately and inserted
+    into JSON request bodies by `request/4`.
+  - `api_host` - PostHog ingestion host, such as `https://us.i.posthog.com`.
+
+  ## Returns
+
+  Returns a `t:t/0` whose `:client` field is a configured `t:Req.Request.t/0`
+  and whose `:module` field is `PostHog.API.Client`.
+  """
   @impl __MODULE__
+  @spec client(String.t(), String.t()) :: t()
   def client(api_key, api_host) do
     client =
       Req.new(base_url: api_host, retry: :transient, compress_body: true)
@@ -132,7 +162,27 @@ defmodule PostHog.API.Client do
     %__MODULE__{client: client, module: __MODULE__}
   end
 
+  @doc """
+  Sends an API request with the default Req-backed client.
+
+  ## Parameters
+
+  - `client` - `t:client/0` returned by `client/2`.
+  - `method` - HTTP method atom, for example `:post`.
+  - `url` - path relative to the configured API host.
+  - `opts` - Req options for the request.
+
+  ## Returns
+
+  Returns `t:response/0`.
+
+  ## Remarks
+
+  When `opts` contains a `:json` body, the configured API key is added to that
+  body unless an `:api_key` is already present.
+  """
   @impl __MODULE__
+  @spec request(client(), atom(), String.t(), keyword()) :: response()
   def request(client, method, url, opts) do
     client
     |> Req.merge(

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -138,22 +138,7 @@ defmodule PostHog.API.Client do
   @callback request(client :: client(), method :: atom(), url :: String.t(), opts :: keyword()) ::
               response()
 
-  @doc """
-  Creates the default Req-backed PostHog API client.
-
-  ## Parameters
-
-  - `api_key` - PostHog project API key. It is stored privately and inserted
-    into JSON request bodies by `request/4`.
-  - `api_host` - PostHog ingestion host, such as `https://us.i.posthog.com`.
-
-  ## Returns
-
-  Returns a `t:t/0` whose `:client` field is a configured `t:Req.Request.t/0`
-  and whose `:module` field is `PostHog.API.Client`.
-  """
   @impl __MODULE__
-  @spec client(String.t(), String.t()) :: t()
   def client(api_key, api_host) do
     client =
       Req.new(base_url: api_host, retry: :transient, compress_body: true)
@@ -162,27 +147,7 @@ defmodule PostHog.API.Client do
     %__MODULE__{client: client, module: __MODULE__}
   end
 
-  @doc """
-  Sends an API request with the default Req-backed client.
-
-  ## Parameters
-
-  - `client` - `t:client/0` returned by `client/2`.
-  - `method` - HTTP method atom, for example `:post`.
-  - `url` - path relative to the configured API host.
-  - `opts` - Req options for the request.
-
-  ## Returns
-
-  Returns `t:response/0`.
-
-  ## Remarks
-
-  When `opts` contains a `:json` body, the configured API key is added to that
-  body unless an `:api_key` is already present.
-  """
   @impl __MODULE__
-  @spec request(client(), atom(), String.t(), keyword()) :: response()
   def request(client, method, url, opts) do
     client
     |> Req.merge(

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -7,7 +7,8 @@ defmodule PostHog.Config do
     test_mode: [
       type: :boolean,
       default: false,
-      doc: "Test mode allows tests assert captured events."
+      doc:
+        "Test mode drops events in memory so tests can assert captured events without sending them to PostHog."
     ]
   ]
 
@@ -51,6 +52,21 @@ defmodule PostHog.Config do
                             type: :map,
                             default: %{},
                             doc: "Map of properties that should be added to all events"
+                          ],
+                          sender_pool_size: [
+                            type: :pos_integer,
+                            doc:
+                              "Number of background sender workers used to batch and send events. Defaults to `max(System.schedulers_online(), 2)`."
+                          ],
+                          max_batch_time_ms: [
+                            type: :non_neg_integer,
+                            doc:
+                              "Maximum time, in milliseconds, to wait before flushing a non-empty event batch. Defaults to `10_000`."
+                          ],
+                          max_batch_events: [
+                            type: :pos_integer,
+                            doc:
+                              "Maximum number of events to collect before flushing a batch immediately. Defaults to `100`."
                           ],
                           in_app_otp_apps: [
                             type: {:list, :atom},
@@ -134,12 +150,21 @@ defmodule PostHog.Config do
   """
 
   @typedoc """
-  Map containing valid configuration.
+  Map containing validated configuration for a PostHog supervision tree.
 
-  It mostly follows `t:options/0`, but the internal structure shouldn't be relied upon.
+  It mostly follows `t:options/0`, but also includes runtime values such as the
+  initialized API client, resolved in-app modules, and system global properties.
+  The internal structure should not be relied upon outside of starting
+  `PostHog.Supervisor` or reading values through `PostHog.config/1`.
   """
   @opaque config() :: map()
 
+  @typedoc """
+  Keyword options accepted by `validate/1` and `validate!/1`.
+
+  See the module documentation for the full schema, defaults, and remarks for
+  each configuration option.
+  """
   @type options() :: unquote(NimbleOptions.option_typespec(@compiled_configuration_schema))
 
   @doc false
@@ -166,7 +191,9 @@ defmodule PostHog.Config do
   end
 
   @doc """
-  See `validate/1`.
+  Validates configuration and returns a `t:config/0`, raising if validation fails.
+
+  See `validate/1` for the accepted options and return shape.
   """
   @spec validate!(options()) :: config()
   def validate!(options) do
@@ -175,7 +202,21 @@ defmodule PostHog.Config do
   end
 
   @doc """
-  Validates configuration against the schema.
+  Validates configuration against the supervisor schema.
+
+  ## Parameters
+
+  - `options` - keyword list matching `t:options/0`.
+
+  ## Returns
+
+  Returns `{:ok, config}` with a normalized `t:config/0` on success, or
+  `{:error, %NimbleOptions.ValidationError{}}` when the options are invalid.
+
+  ## Remarks
+
+  String `:api_key` and `:api_host` values are trimmed before validation. A blank
+  `:api_host` falls back to the default PostHog US ingestion host.
   """
   @spec validate(options()) ::
           {:ok, config()} | {:error, NimbleOptions.ValidationError.t()}

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -53,21 +53,6 @@ defmodule PostHog.Config do
                             default: %{},
                             doc: "Map of properties that should be added to all events"
                           ],
-                          sender_pool_size: [
-                            type: :pos_integer,
-                            doc:
-                              "Number of background sender workers used to batch and send events. Defaults to `max(System.schedulers_online(), 2)`."
-                          ],
-                          max_batch_time_ms: [
-                            type: :non_neg_integer,
-                            doc:
-                              "Maximum time, in milliseconds, to wait before flushing a non-empty event batch. Defaults to `10_000`."
-                          ],
-                          max_batch_events: [
-                            type: :pos_integer,
-                            doc:
-                              "Maximum number of events to collect before flushing a batch immediately. Defaults to `100`."
-                          ],
                           in_app_otp_apps: [
                             type: {:list, :atom},
                             default: [],

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -8,7 +8,7 @@ defmodule PostHog.Config do
       type: :boolean,
       default: false,
       doc:
-        "Test mode drops events in memory so tests can assert captured events without sending them to PostHog."
+        "Test mode keeps captured events in memory for assertions instead of sending them to PostHog."
     ]
   ]
 

--- a/lib/posthog/error.ex
+++ b/lib/posthog/error.ex
@@ -1,8 +1,13 @@
 defmodule PostHog.Error do
   @moduledoc """
-  PostHog error
+  Generic PostHog SDK error.
+
+  ## Fields
+
+  - `:message` - human-readable error message.
   """
 
+  @typedoc "Exception raised for SDK errors that are not tied to an HTTP response."
   @type t() :: %__MODULE__{message: String.t()}
 
   defexception [:message]
@@ -10,8 +15,15 @@ end
 
 defmodule PostHog.UnexpectedResponseError do
   @moduledoc """
-  PostHog error that includes a reponse from the API, either full or partial.
+  PostHog error that includes a response from the API, either full or partial.
+
+  ## Fields
+
+  - `:message` - human-readable error message.
+  - `:response` - API response data that caused the error.
   """
+
+  @typedoc "Exception raised when PostHog returns a response the SDK cannot handle."
   @type t() :: %__MODULE__{response: any(), message: String.t()}
 
   defexception [:response, :message]

--- a/lib/posthog/feature_flags.ex
+++ b/lib/posthog/feature_flags.ex
@@ -66,7 +66,7 @@ defmodule PostHog.FeatureFlags do
 
   Get all feature flags with full request body:
 
-      PostHog.FeatureFlags.flags_for(%{distinct_id: "user123", group: %{group_type: "group_id"}})
+      PostHog.FeatureFlags.flags_for(%{distinct_id: "user123", groups: %{group_type: "group_id"}})
 
   Get all feature flags for `distinct_id` from the context:
 
@@ -164,21 +164,27 @@ defmodule PostHog.FeatureFlags do
     end
   end
 
-  @doc false
-  def set_in_context(%__MODULE__.Evaluations{} = snapshot),
-    do: set_in_context(PostHog, snapshot)
-
   @doc """
   Copies a snapshot's `$feature/<key>` and `$active_feature_flags` properties
-  into the per-process PostHog context.
+  into the default per-process PostHog context.
+
+  ## Parameters
+
+  - `snapshot` - `t:PostHog.FeatureFlags.Evaluations.t/0` returned by
+    `evaluate_flags/2` or one of the filtering helpers.
+
+  ## Returns
+
+  Returns `:ok`.
+
+  ## Remarks
 
   Any subsequent `PostHog.capture/3` from this process automatically attaches
   these properties to the captured event — no additional `/flags` request,
   with the values guaranteed to match what the snapshot already evaluated.
 
-  This is the idiomatic Elixir way to enrich captured events from an
-  `evaluate_flags/2` snapshot. For one-off enrichment without touching context,
-  merge `PostHog.FeatureFlags.Evaluations.event_properties/1` into a capture's
+  For one-off enrichment without touching context, merge
+  `PostHog.FeatureFlags.Evaluations.event_properties/1` into a capture's
   properties directly.
 
   ## Examples
@@ -188,6 +194,29 @@ defmodule PostHog.FeatureFlags do
 
       # All subsequent captures pick up $feature/* and $active_feature_flags
       PostHog.capture("page_viewed", %{distinct_id: "user123"})
+  """
+  @spec set_in_context(__MODULE__.Evaluations.t()) :: :ok
+  def set_in_context(%__MODULE__.Evaluations{} = snapshot),
+    do: set_in_context(PostHog, snapshot)
+
+  @doc """
+  Copies a snapshot's `$feature/<key>` and `$active_feature_flags` properties
+  into a named PostHog instance's per-process context.
+
+  ## Parameters
+
+  - `name` - supervisor name of the PostHog instance whose context should be
+    updated.
+  - `snapshot` - `t:PostHog.FeatureFlags.Evaluations.t/0` returned by
+    `evaluate_flags/2` or one of the filtering helpers.
+
+  ## Returns
+
+  Returns `:ok`.
+
+  ## Remarks
+
+  This is the named-instance variant of `set_in_context/1`.
   """
   @spec set_in_context(PostHog.supervisor_name(), __MODULE__.Evaluations.t()) :: :ok
   def set_in_context(name, %__MODULE__.Evaluations{} = snapshot) when is_atom(name) do
@@ -245,7 +274,7 @@ defmodule PostHog.FeatureFlags do
 
   Check boolean feature flag through a named PostHog instance:
 
-      PostHog.check(MyPostHog, "example-feature-flag-1", "user123")
+      PostHog.FeatureFlags.check(MyPostHog, "example-feature-flag-1", "user123")
   """
   @spec check(PostHog.supervisor_name(), String.t(), PostHog.distinct_id() | map() | nil) ::
           {:ok, boolean()} | {:ok, String.t()} | {:error, Exception.t()}

--- a/lib/posthog/feature_flags/evaluations.ex
+++ b/lib/posthog/feature_flags/evaluations.ex
@@ -229,7 +229,7 @@ defmodule PostHog.FeatureFlags.Evaluations do
       properties = PostHog.FeatureFlags.Evaluations.event_properties(snapshot)
       PostHog.capture("page_viewed", Map.merge(%{distinct_id: "u1"}, properties))
   """
-  @spec event_properties(t()) :: %{String.t() => any()}
+  @spec event_properties(t()) :: PostHog.properties()
   def event_properties(%__MODULE__{flags: flags}) do
     {properties, active} =
       Enum.reduce(flags, {%{}, []}, fn {key, %Result{} = result}, {props, active} ->

--- a/lib/posthog/feature_flags/result.ex
+++ b/lib/posthog/feature_flags/result.ex
@@ -47,8 +47,15 @@ defmodule PostHog.FeatureFlags.Result do
       }
   """
 
+  @typedoc "JSON-compatible value used for feature flag payloads."
   @type json :: String.t() | number() | boolean() | nil | [json()] | %{String.t() => json()}
 
+  @typedoc """
+  Result for a single evaluated feature flag.
+
+  The struct fields mirror the data returned by PostHog's `/flags` endpoint and
+  the metadata emitted on `$feature_flag_called` events.
+  """
   @type t :: %__MODULE__{
           key: String.t(),
           enabled: boolean(),

--- a/lib/posthog/integrations/llm_analytics/req.ex
+++ b/lib/posthog/integrations/llm_analytics/req.ex
@@ -72,16 +72,29 @@ defmodule PostHog.Integrations.LLMAnalytics.Req do
   alias PostHog.LLMAnalytics
 
   @doc """
-  Attach plugin to a `Req.Request` struct.
+  Attaches the LLM Analytics plugin to a `Req.Request` struct.
 
-  The plugin registers the `posthog_supervisor` option. Use it if you run a [custom
-  PostHog instance](advanced-configuration.md).
+  ## Parameters
+
+  - `request` - the `Req.Request` to instrument.
+  - `options` - plugin options merged into the request.
+
+  ## Options
+
+  - `:posthog_supervisor` - PostHog supervisor name to capture through. Use this
+    if you run a [custom PostHog instance](advanced-configuration.md).
+
+  ## Returns
+
+  Returns the updated `Req.Request` with request, response, and error steps
+  installed.
 
   ## Examples
 
       iex> Req.new() |> PostHog.Integrations.LLMAnalytics.Req.attach()
       iex> Req.new() |> PostHog.Integrations.LLMAnalytics.Req.attach(posthog_supervisor: MyPostHog)
   """
+  @spec attach(Req.Request.t(), keyword()) :: Req.Request.t()
   def attach(%Req.Request{} = request, options \\ []) do
     request
     |> Req.Request.register_options([:posthog_supervisor])

--- a/lib/posthog/llm_analytics.ex
+++ b/lib/posthog/llm_analytics.ex
@@ -136,7 +136,7 @@ defmodule PostHog.LLMAnalytics do
     {:ok, span_id} = LLMAnalytics.capture_span("$ai_span", %{"$ai_span_name": "top level", "$ai_input_state": user_message})
     
     Task.async(fn -> 
-      LLMAnalytics.set_session(session)
+      LLMAnalytics.set_session(session_id)
       LLMAnalytics.set_trace(trace_id)
       LLMAnalytics.set_root_span(span_id)
       
@@ -145,7 +145,7 @@ defmodule PostHog.LLMAnalytics do
       ...
     end)
     
-    Req.post!("https://api.openai.com/v1/responses, json: %{input: user_message})
+    Req.post!("https://api.openai.com/v1/responses", json: %{input: user_message})
     ...
   end
   ```
@@ -295,8 +295,7 @@ defmodule PostHog.LLMAnalytics do
   @doc """
   Get root span ID for a process.
 
-  Use this function to get propagate current process' root span to a new
-  process. 
+  Use this function to propagate current process' root span to a new process.
 
   ## Examples
 
@@ -309,7 +308,7 @@ defmodule PostHog.LLMAnalytics do
       iex> PostHog.LLMAnalytics.get_root_span(MyPostHog)
       nil
   """
-  @spec get_root_span(PostHog.supervisor_name()) :: span_id()
+  @spec get_root_span(PostHog.supervisor_name()) :: span_id() | nil
   def get_root_span(name \\ PostHog) do
     Process.get({name, @root_span_key})
   end

--- a/lib/posthog/supervisor.ex
+++ b/lib/posthog/supervisor.ex
@@ -1,10 +1,26 @@
 defmodule PostHog.Supervisor do
   @moduledoc """
-  Supervisor that manages all processes required for logging. By default,
-  `PostHog` starts it automatically.
+  Supervisor that manages the processes required for PostHog event capture.
+
+  By default, `PostHog` starts this supervisor automatically from the `:posthog`
+  application configuration. Start it yourself when you need a custom supervision
+  tree or multiple PostHog instances.
   """
   use Supervisor
 
+  @doc """
+  Returns a child specification for a PostHog supervision tree.
+
+  ## Parameters
+
+  - `config` - validated `t:PostHog.Config.config/0` for the instance.
+
+  ## Returns
+
+  A `t:Supervisor.child_spec/0` that can be included in your application's
+  children list.
+  """
+  @spec child_spec(PostHog.Config.config()) :: Supervisor.child_spec()
   def child_spec(config) do
     Supervisor.child_spec(
       %{
@@ -16,6 +32,18 @@ defmodule PostHog.Supervisor do
     )
   end
 
+  @doc """
+  Starts a PostHog supervision tree from a validated config.
+
+  ## Parameters
+
+  - `config` - validated `t:PostHog.Config.config/0`. Use
+    `PostHog.Config.validate!/1` before calling this function with raw options.
+
+  ## Returns
+
+  Returns the standard `t:Supervisor.on_start/0` tuple.
+  """
   @spec start_link(PostHog.Config.config()) :: Supervisor.on_start()
   def start_link(config) do
     callers = Process.get(:"$callers", [])

--- a/lib/posthog/test.ex
+++ b/lib/posthog/test.ex
@@ -120,7 +120,7 @@ defmodule PostHog.Test do
           :go -> :ok
         end
 
-        PostHog.capture("event", "user123")
+        PostHog.capture("event", %{distinct_id: "user123"})
         send(test_pid, :ready)
       end)
 
@@ -160,7 +160,7 @@ defmodule PostHog.Test do
 
   ## Examples:
 
-      setup :set_posthog_shared
+      setup {PostHog.Test, :set_posthog_shared}
   """
   @spec set_posthog_shared(map()) :: :ok
   def set_posthog_shared(_test_context \\ %{}) do

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,13 @@ defmodule PostHog.MixProject do
       assets: %{
         "assets" => "assets"
       },
-      extras: ["README.md", "CHANGELOG.md", "MIGRATION.md", "guides/advanced-configuration.md"],
+      extras: [
+        "README.md",
+        "CHANGELOG.md",
+        "MIGRATION.md",
+        "CONTRIBUTING.md",
+        "guides/advanced-configuration.md"
+      ],
       groups_for_modules: [
         Integrations: [PostHog.Integrations.Plug, PostHog.Integrations.LLMAnalytics.Req],
         Testing: [PostHog.Test]

--- a/test/posthog/config_test.exs
+++ b/test/posthog/config_test.exs
@@ -60,6 +60,28 @@ defmodule PostHog.ConfigTest do
     assert config.api_host == "https://us.i.posthog.com"
   end
 
+  test "validate accepts batching options" do
+    expect(PostHog.API.Mock, :client, fn api_key, api_host ->
+      assert api_key == "project_api_key"
+      assert api_host == "https://us.i.posthog.com"
+
+      %PostHog.API.Client{client: :stub_client, module: PostHog.API.Mock}
+    end)
+
+    assert {:ok, config} =
+             PostHog.Config.validate(
+               api_key: "project_api_key",
+               api_client_module: PostHog.API.Mock,
+               sender_pool_size: 3,
+               max_batch_time_ms: 250,
+               max_batch_events: 10
+             )
+
+    assert config.sender_pool_size == 3
+    assert config.max_batch_time_ms == 250
+    assert config.max_batch_events == 10
+  end
+
   test "validate logs when api_key is blank after trimming whitespace" do
     expect(PostHog.API.Mock, :client, fn api_key, api_host ->
       assert api_key == ""

--- a/test/posthog/config_test.exs
+++ b/test/posthog/config_test.exs
@@ -60,28 +60,6 @@ defmodule PostHog.ConfigTest do
     assert config.api_host == "https://us.i.posthog.com"
   end
 
-  test "validate accepts batching options" do
-    expect(PostHog.API.Mock, :client, fn api_key, api_host ->
-      assert api_key == "project_api_key"
-      assert api_host == "https://us.i.posthog.com"
-
-      %PostHog.API.Client{client: :stub_client, module: PostHog.API.Mock}
-    end)
-
-    assert {:ok, config} =
-             PostHog.Config.validate(
-               api_key: "project_api_key",
-               api_client_module: PostHog.API.Mock,
-               sender_pool_size: 3,
-               max_batch_time_ms: 250,
-               max_batch_events: 10
-             )
-
-    assert config.sender_pool_size == 3
-    assert config.max_batch_time_ms == 250
-    assert config.max_batch_events == 10
-  end
-
   test "validate logs when api_key is blank after trimming whitespace" do
     expect(PostHog.API.Mock, :client, fn api_key, api_host ->
       assert api_key == ""


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Public SDK APIs, configuration docs, and return types should be discoverable and up to date in ExDoc. This documents missing public APIs and fixes stale examples/spec docs so HexDocs matches the current implementation and official Elixir library docs.

Callback implementations remain hidden behind their behaviour callbacks; only the callback/type documentation is exposed for those APIs. Internal sender tuning options remain undocumented.

## :green_heart: How did you test it?

- `mix format`
- `mix compile --warnings-as-errors`
- `mix docs`
- `mix test`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
