### PR TITLE
fix(error-tracking): always use arity when formatting stacktrace frames

### DIFF
--- a/.sampo/changesets/somber-knight-otso.md
+++ b/.sampo/changesets/somber-knight-otso.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Improve error tracking grouping by always using arity to format stacktrace frames

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -211,11 +211,12 @@ defmodule PostHog.Handler do
         in_app = module in in_app_modules
         filename = Keyword.get(location, :file, []) |> IO.chardata_to_string()
         lineno = Keyword.get(location, :line)
+        arity = with args when is_list(args) <- arity_or_args, do: length(args)
 
         %{
           platform: "custom",
           lang: "elixir",
-          function: Exception.format_mfa(module, function, arity_or_args),
+          function: Exception.format_mfa(module, function, arity),
           filename: filename,
           lineno: lineno,
           module: inspect(module),

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -23,8 +23,14 @@ defmodule PostHog.IntegrationTest do
         |> PostHog.Registry.via(PostHog.Sender, 1)
         |> GenServer.whereis()
 
-      send(sender_pid, :batch_time_reached)
-      :sys.get_status(sender_pid)
+      case :sys.get_state(sender_pid) do
+        %{timer_ref: ref} ->
+          send(sender_pid, {:timeout, ref, :batch_time_reached})
+          :sys.get_status(sender_pid)
+
+        _ ->
+          :ok
+      end
     end
 
     :logger.add_handler(:posthog, PostHog.Handler, %{config: config})
@@ -70,6 +76,18 @@ defmodule PostHog.IntegrationTest do
 
     test "task exit", %{wait_fun: wait} do
       LoggerHandlerKit.Act.task_error(:exit)
+      wait.()
+    end
+
+    test "anonymous function", %{wait_fun: wait} do
+      {:ok, pid} =
+        Task.start(fn ->
+          Enum.map([:foo], fn x when is_binary(x) -> :ok end)
+        end)
+
+      ref = Process.monitor(pid)
+      assert_receive({:DOWN, ^ref, _, _, _})
+
       wait.()
     end
 

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -1639,7 +1639,7 @@ defmodule PostHog.HandlerTest do
                        frames: [
                          %{
                            filename: "",
-                           function: ":erlang.system_time(:foo)",
+                           function: ":erlang.system_time/1",
                            in_app: false,
                            lineno: nil,
                            module: ":erlang",
@@ -1668,10 +1668,78 @@ defmodule PostHog.HandlerTest do
                        frames: [
                          %{
                            filename: "",
-                           function: ":erlang.system_time(:foo)",
+                           function: ":erlang.system_time/1",
                            in_app: false,
                            lineno: nil,
                            module: ":erlang",
+                           platform: "custom",
+                           lang: "elixir"
+                         }
+                         | _
+                       ]
+                     },
+                     mechanism: %{type: "generic", handled: false}
+                   },
+                   %{
+                     mechanism: %{handled: true, type: "generic"},
+                     type: "Task terminating"
+                   }
+                 ]
+               }
+             } = event
+    end
+  end
+
+  test "anonymous function in stacktrace", %{
+    handler_ref: ref,
+    config: %{supervisor_name: supervisor_name}
+  } do
+    {:ok, _pid} = Task.start(fn -> Enum.map([:foo], fn :bar -> :ok end) end)
+    LoggerHandlerKit.Assert.assert_logged(ref)
+
+    assert [event] = all_captured(supervisor_name)
+
+    if pre_19?() do
+      assert %{
+               event: "$exception",
+               properties: %{
+                 "$exception_list": [
+                   %{
+                     type: "FunctionClauseError",
+                     value:
+                       "no function clause matching in anonymous fn/1 in PostHog.HandlerTest.\"test anonymous function in stacktrace\"/1",
+                     stacktrace: %{
+                       type: "raw",
+                       frames: [
+                         %{
+                           function:
+                             "anonymous fn/1 in PostHog.HandlerTest.\"test anonymous function in stacktrace\"/1",
+                           platform: "custom",
+                           lang: "elixir"
+                         }
+                         | _
+                       ]
+                     },
+                     mechanism: %{type: "generic", handled: false}
+                   }
+                 ]
+               }
+             } = event
+    else
+      assert %{
+               event: "$exception",
+               properties: %{
+                 "$exception_list": [
+                   %{
+                     type: "FunctionClauseError",
+                     value:
+                       "no function clause matching in anonymous fn/1 in PostHog.HandlerTest.\"test anonymous function in stacktrace\"/1",
+                     stacktrace: %{
+                       type: "raw",
+                       frames: [
+                         %{
+                           function:
+                             "anonymous fn/1 in PostHog.HandlerTest.\"test anonymous function in stacktrace\"/1",
                            platform: "custom",
                            lang: "elixir"
                          }


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR replaces https://github.com/PostHog/posthog-elixir/pull/119

The problem is that PostHog Error Tracking uses resolved function name as part of the fingerprint for issue grouping. This is fine, but in Elixir SDK function name comes from the stacktrace frames, which are formatted using `Exception.format_mfa(module, function, arity_or_args)`. `arity_or_args` is exactly that: arity or args. When it's arity, it's a simple integer that is stable across all calls. But when it's args, it's a dynamic value. So when included in the fingerprint, it prevents errors from grouping.

The solution in this PR is to always use arity for formatting, even if we are passed arguments. 


## :green_heart: How did you test it?

Unit and integration tests


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->

Closes #119