### PR TITLE
feat: emit $is_server property on captured events

### DIFF
--- a/.sampo/changesets/is-server-property.md
+++ b/.sampo/changesets/is-server-property.md
@@ -2,4 +2,4 @@
 hex/posthog: patch
 ---
 
-Emit `$is_server` property on captured events so PostHog can identify server-side events.
+Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `is_server: false` when using posthog-elixir as a client/CLI so the device OS is attributed normally.

--- a/.sampo/changesets/is-server-property.md
+++ b/.sampo/changesets/is-server-property.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Emit `$is_server` property on captured events so PostHog can identify server-side events.

--- a/.sampo/changesets/is-server-property.md
+++ b/.sampo/changesets/is-server-property.md
@@ -1,5 +1,5 @@
 ---
-hex/posthog: patch
+hex/posthog: minor
 ---
 
 Add a configurable `$is_server` event property (default `true`) so PostHog can identify server-side events. Set `is_server: false` when using posthog-elixir as a client/CLI so the device OS is attributed normally.

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -114,7 +114,8 @@ defmodule PostHog.Config do
 
   @system_global_properties %{
     "$lib": "posthog-elixir",
-    "$lib_version": Mix.Project.config()[:version]
+    "$lib_version": Mix.Project.config()[:version],
+    "$is_server": true
   }
 
   @moduledoc """

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -54,6 +54,12 @@ defmodule PostHog.Config do
                             default: %{},
                             doc: "Map of properties that should be added to all events"
                           ],
+                          is_server: [
+                            type: :boolean,
+                            default: true,
+                            doc:
+                              "Whether this SDK runs as a server. When `true` (the default), a `$is_server: true` property is added to all events so PostHog attributes them as server-side. Set to `false` when using posthog-elixir as a client/CLI so the device OS is attributed normally."
+                          ],
                           in_app_otp_apps: [
                             type: {:list, :atom},
                             default: [],
@@ -114,8 +120,7 @@ defmodule PostHog.Config do
 
   @system_global_properties %{
     "$lib": "posthog-elixir",
-    "$lib_version": Mix.Project.config()[:version],
-    "$is_server": true
+    "$lib_version": Mix.Project.config()[:version]
   }
 
   @moduledoc """
@@ -224,7 +229,14 @@ defmodule PostHog.Config do
           config.api_client_module.client(config.api_key, config.api_host)
         end
 
-      global_properties = Map.merge(config.global_properties, @system_global_properties)
+      system_global_properties =
+        if config.is_server do
+          Map.put(@system_global_properties, :"$is_server", true)
+        else
+          @system_global_properties
+        end
+
+      global_properties = Map.merge(config.global_properties, system_global_properties)
 
       final_config =
         config

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -128,7 +128,8 @@ defmodule PostHogTest do
 
       assert [%{properties: properties}] = all_captured()
 
-      assert %{foo: "bar", "$lib": "posthog-elixir", "$lib_version": _} = properties
+      assert %{foo: "bar", "$lib": "posthog-elixir", "$lib_version": _, "$is_server": true} =
+               properties
       refute properties[:hello]
     end
 

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -67,7 +67,8 @@ defmodule PostHogTest do
                  egg: "spam",
                  struct: %{hello: nil},
                  "$lib": "posthog-elixir",
-                 "$lib_version": _
+                 "$lib_version": _,
+                 "$is_server": true
                },
                timestamp: _
              } = event

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -80,15 +80,9 @@ defmodule PostHogTest do
     test "omits $is_server when is_server is false" do
       PostHog.bare_capture("case tested", "distinct_id")
 
-      assert [event] = all_captured()
+      assert [%{properties: properties}] = all_captured()
 
-      assert %{
-               properties: %{
-                 "$lib": "posthog-elixir",
-                 "$lib_version": _
-               } = properties
-             } = event
-
+      assert %{"$lib": "posthog-elixir", "$lib_version": _} = properties
       refute Map.has_key?(properties, :"$is_server")
     end
 
@@ -128,8 +122,8 @@ defmodule PostHogTest do
 
       assert [%{properties: properties}] = all_captured()
 
-      assert %{foo: "bar", "$lib": "posthog-elixir", "$lib_version": _, "$is_server": true} =
-               properties
+      assert %{foo: "bar", "$lib": "posthog-elixir", "$lib_version": _} = properties
+      assert properties[:"$is_server"] == true
       refute properties[:hello]
     end
 

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -76,6 +76,22 @@ defmodule PostHogTest do
       Jason.encode!(event)
     end
 
+    @tag config: [is_server: false, supervisor_name: PostHog]
+    test "omits $is_server when is_server is false" do
+      PostHog.bare_capture("case tested", "distinct_id")
+
+      assert [event] = all_captured()
+
+      assert %{
+               properties: %{
+                 "$lib": "posthog-elixir",
+                 "$lib_version": _
+               } = properties
+             } = event
+
+      refute Map.has_key?(properties, :"$is_server")
+    end
+
     @tag config: [supervisor_name: CustomPostHog]
     test "simple call for custom supervisor" do
       PostHog.bare_capture(CustomPostHog, "case tested", "distinct_id")


### PR DESCRIPTION
Adds `$is_server: true` to every event captured by this SDK so PostHog ingestion can identify server-side events.