### PR TITLE
chore: fix Elixir 1.20 warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,29 @@ jobs:
     # See https://hexdocs.pm/elixir/compatibility-and-deprecations.html#between-elixir-and-erlang-otp
     strategy:
       matrix:
-        elixir: ["1.17.x", "1.18.x", "1.19.x"]
-        otp: ["25.x", "26.x", "27.x", "28.x"]
+        elixir: ["1.17.x", "1.18.x", "1.19.x", "1.20.x"]
+        otp: ["25.x", "26.x", "27.x", "28.x", "29.x"]
         exclude:
-          # Elixir 1.17 doesn't support OTP 28
+          # Elixir 1.17 doesn't support OTP 28+
           - elixir: "1.17.x"
             otp: "28.x"
-          # Elixir 1.18 doesn't support OTP 28
+          - elixir: "1.17.x"
+            otp: "29.x"
+          # Elixir 1.18 doesn't support OTP 28+
           - elixir: "1.18.x"
             otp: "28.x"
-          # Elixir 1.19 doesn't support OTP 25
+          - elixir: "1.18.x"
+            otp: "29.x"
+          # Elixir 1.19 doesn't support OTP 25 and OTP 29
           - elixir: "1.19.x"
             otp: "25.x"
+          - elixir: "1.19.x"
+            otp: "29.x"
+          # Elixir 1.20 doesn't support OTP <= 25
+          - elixir: "1.20.x"
+            otp: "25.x"
+          - elixir: "1.20.x"
+            otp: "26.x"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19.5-otp-28
-erlang 28.3.1
+elixir 1.20.0-otp-29
+erlang 29.0.1

--- a/lib/posthog/integrations/plug.ex
+++ b/lib/posthog/integrations/plug.ex
@@ -108,8 +108,6 @@ defmodule PostHog.Integrations.Plug do
     if value == "", do: nil, else: value
   end
 
-  defp sanitize_value(_value), do: nil
-
   defp put_if_present(map, _key, nil), do: map
   defp put_if_present(map, key, value), do: Map.put(map, key, value)
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Elixir 1.20 [released today](https://elixir-lang.org/blog/2026/06/03/elixir-v1-20-0-released/) with a ton of new compiler checks related to the type system. For posthog sdk, there was just one warning for an unreachable clause, so let's fix it.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
