### PR TITLE
docs: update Sentry license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,15 +4,28 @@ Copyright © 2020 White Paper Clip, Inc.
 
 ---
 
-Portions of this software are inspired by getsentry/sentry-elixir by Software, Inc. dba Sentry under the MIT license. In such cases it is explicitly stated in the file header.
+Some files in this codebase contain code from getsentry/sentry-elixir.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
+
+The MIT License (MIT)
 
 Copyright (c) 2014 Stanislav Vishnevskiy
 Copyright (c) 2023 Functional Software, Inc. dba Sentry
 
----
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/mix/tasks/posthog.package_source_code.ex
+++ b/lib/mix/tasks/posthog.package_source_code.ex
@@ -1,5 +1,7 @@
-# Portions of this file are inspired from getsentry/sentry-elixir
-# (lib/mix/tasks/sentry.package_source_code.ex) by Software, Inc. dba Sentry, used under the MIT License.
+# Portions of this file are derived from getsentry/sentry-elixir
+# Copyright (c) 2014 Stanislav Vishnevskiy
+# Copyright (c) 2023 Functional Software, Inc. dba Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-elixir/blob/master/LICENSE
 
 defmodule Mix.Tasks.Posthog.PackageSourceCode do
   @moduledoc """

--- a/lib/posthog/error_tracking/sources.ex
+++ b/lib/posthog/error_tracking/sources.ex
@@ -1,5 +1,7 @@
-# Portions of this file are inspired from getsentry/sentry-elixir
-# (lib/sentry/sources.ex) by Software, Inc. dba Sentry, used under the MIT License.
+# Portions of this file are derived from getsentry/sentry-elixir
+# Copyright (c) 2014 Stanislav Vishnevskiy
+# Copyright (c) 2023 Functional Software, Inc. dba Sentry
+# Licensed under the MIT License: https://github.com/getsentry/sentry-elixir/blob/master/LICENSE
 
 defmodule PostHog.ErrorTracking.Sources do
   @moduledoc false


### PR DESCRIPTION
## :bulb: Motivation and Context

Update the Sentry-derived source attribution to include all copyright holders from the upstream Sentry license.

## :green_heart: How did you test it?

Not run; attribution/comment-only change.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
