### PR TITLE
chore: make source map tests line-number resilient

### DIFF
--- a/test/posthog/error_tracking/sources_test.exs
+++ b/test/posthog/error_tracking/sources_test.exs
@@ -27,6 +27,17 @@ defmodule PostHog.ErrorTracking.SourcesTest do
     supervisor_name
   end
 
+  defp line_number_for(path, expected_line) do
+    path
+    |> File.read!()
+    |> String.replace_suffix("\n", "")
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.find_value(fn {line, line_number} ->
+      if line == expected_line, do: line_number
+    end)
+  end
+
   describe "get_source_context/3" do
     setup do
       source_map = %{
@@ -116,11 +127,14 @@ defmodule PostHog.ErrorTracking.SourcesTest do
     test "returns source map for a loaded file" do
       supervisor_name = start_sources!(root_source_code_paths: [File.cwd!()])
 
-      result =
-        Sources.get_source_map_for_file(supervisor_name, "lib/posthog/error_tracking/sources.ex")
+      source_path = "lib/posthog/error_tracking/sources.ex"
+      source_line = "defmodule PostHog.ErrorTracking.Sources do"
+      line_number = line_number_for(source_path, source_line)
+
+      result = Sources.get_source_map_for_file(supervisor_name, source_path)
 
       assert is_map(result)
-      assert result[4] == "defmodule PostHog.ErrorTracking.Sources do"
+      assert result[line_number] == source_line
     end
   end
 
@@ -158,9 +172,13 @@ defmodule PostHog.ErrorTracking.SourcesTest do
       assert Enum.all?(result, fn {path, _} -> String.ends_with?(path, ".ex") end)
 
       # Spot-check a known file: sources.ex itself
-      source_lines = result["lib/posthog/error_tracking/sources.ex"]
+      source_path = "lib/posthog/error_tracking/sources.ex"
+      source_line = "defmodule PostHog.ErrorTracking.Sources do"
+      line_number = line_number_for(source_path, source_line)
+
+      source_lines = result[source_path]
       assert is_map(source_lines)
-      assert source_lines[4] == "defmodule PostHog.ErrorTracking.Sources do"
+      assert source_lines[line_number] == source_line
     end
 
     test "excludes directories matching the default patterns" do


### PR DESCRIPTION
## :bulb: Motivation and Context
Main CI is failing because `SourcesTest` hard-coded that `defmodule PostHog.ErrorTracking.Sources do` appears on line 4 of `lib/posthog/error_tracking/sources.ex`. The recent license attribution header moved that line down, so the tests failed even though source map line mapping still works correctly.

This updates the tests to derive the expected line number from the fixture file content instead of relying on a brittle hard-coded line number.

## :green_heart: How did you test it?

- `mix test test/posthog/error_tracking/sources_test.exs`
- `mix test`
- `mix format --check-formatted`
- `mix credo --strict`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
