### PR TITLE
feat: send posthog-elixir User-Agent header by default

### DIFF
--- a/.sampo/changesets/default-user-agent.md
+++ b/.sampo/changesets/default-user-agent.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Send a `posthog-elixir/<version>` User-Agent header on all API requests so PostHog recognizes the SDK as server-side and includes flags gated to the server runtime in `/flags` responses.

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -141,7 +141,12 @@ defmodule PostHog.API.Client do
   # PostHog uses the User-Agent to identify the SDK and classify it as
   # server-side; without it, flags gated to the server runtime are omitted
   # from /flags responses.
-  @user_agent "posthog-elixir/#{Mix.Project.config()[:version]}"
+  @user_agent PostHog.Lib.user_agent()
+
+  @doc """
+  The User-Agent header value sent with every API request.
+  """
+  def user_agent, do: @user_agent
 
   @impl __MODULE__
   def client(api_key, api_host) do

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -138,10 +138,20 @@ defmodule PostHog.API.Client do
   @callback request(client :: client(), method :: atom(), url :: String.t(), opts :: keyword()) ::
               response()
 
+  # PostHog uses the User-Agent to identify the SDK and classify it as
+  # server-side; without it, flags gated to the server runtime are omitted
+  # from /flags responses.
+  @user_agent "posthog-elixir/#{Mix.Project.config()[:version]}"
+
   @impl __MODULE__
   def client(api_key, api_host) do
     client =
-      Req.new(base_url: api_host, retry: :transient, compress_body: true)
+      Req.new(
+        base_url: api_host,
+        retry: :transient,
+        compress_body: true,
+        headers: [{"user-agent", @user_agent}]
+      )
       |> Req.Request.put_private(:api_key, api_key)
 
     %__MODULE__{client: client, module: __MODULE__}

--- a/lib/posthog/config.ex
+++ b/lib/posthog/config.ex
@@ -119,8 +119,8 @@ defmodule PostHog.Config do
   @compiled_convenience_schema NimbleOptions.new!(@convenience_schema)
 
   @system_global_properties %{
-    "$lib": "posthog-elixir",
-    "$lib_version": Mix.Project.config()[:version]
+    "$lib": PostHog.Lib.name(),
+    "$lib_version": PostHog.Lib.version()
   }
 
   @moduledoc """

--- a/lib/posthog/lib.ex
+++ b/lib/posthog/lib.ex
@@ -1,0 +1,10 @@
+defmodule PostHog.Lib do
+  @moduledoc false
+
+  @name "posthog-elixir"
+  @version Mix.Project.config()[:version]
+
+  def name, do: @name
+  def version, do: @version
+  def user_agent, do: "#{@name}/#{@version}"
+end

--- a/test/posthog/api/client_test.exs
+++ b/test/posthog/api/client_test.exs
@@ -1,10 +1,11 @@
 defmodule PostHog.API.ClientTest do
   use ExUnit.Case, async: true
 
-  test "client/2 sets the posthog-elixir User-Agent" do
-    %PostHog.API.Client{client: req} =
-      PostHog.API.Client.client("phc_test", "https://us.i.posthog.com")
+  alias PostHog.API.Client
 
-    assert req.headers["user-agent"] == [PostHog.API.Client.user_agent()]
+  test "client/2 sets the posthog-elixir User-Agent" do
+    %Client{client: req} = Client.client("phc_test", "https://us.i.posthog.com")
+
+    assert req.headers["user-agent"] == [Client.user_agent()]
   end
 end

--- a/test/posthog/api/client_test.exs
+++ b/test/posthog/api/client_test.exs
@@ -1,0 +1,11 @@
+defmodule PostHog.API.ClientTest do
+  use ExUnit.Case, async: true
+
+  test "client/2 sets the posthog-elixir User-Agent" do
+    %PostHog.API.Client{client: req} =
+      PostHog.API.Client.client("phc_test", "https://us.i.posthog.com")
+
+    version = Mix.Project.config()[:version]
+    assert req.headers["user-agent"] == ["posthog-elixir/#{version}"]
+  end
+end

--- a/test/posthog/api/client_test.exs
+++ b/test/posthog/api/client_test.exs
@@ -5,7 +5,6 @@ defmodule PostHog.API.ClientTest do
     %PostHog.API.Client{client: req} =
       PostHog.API.Client.client("phc_test", "https://us.i.posthog.com")
 
-    version = Mix.Project.config()[:version]
-    assert req.headers["user-agent"] == ["posthog-elixir/#{version}"]
+    assert req.headers["user-agent"] == [PostHog.API.Client.user_agent()]
   end
 end


### PR DESCRIPTION
## :bulb: Motivation and Context

The default Req client sends Req's own User-Agent (`req/<version>`), so PostHog's `/flags` endpoint can't identify the SDK and treats requests as an unknown runtime. Flags with `evaluation_runtime: "server"` are then filtered out of the response.

The backend already recognizes `posthog-elixir` as a server-side SDK; the SDK just never identified itself. This sets a default `posthog-elixir/<version>` User-Agent on all API requests so server-gated flags work out of the box. Custom client implementations can still override the header as before.

## :green_heart: How did you test it?

Added a unit test asserting `client/2` sets the `posthog-elixir/<version>` header. Full suite passes (302 tests, 0 failures).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file