### PR TITLE
chore: add Hex package build CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,5 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
-
       - name: Build Hex package
         run: mix hex.build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,31 @@ jobs:
 
       - name: Compile with warnings as errors
         run: mix compile --warnings-as-errors
+
+  package:
+    name: Hex package build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-${{ env.ELIXIR_VERSION }}-
+            ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-
+            ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Build Hex package
+        run: mix hex.build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,18 +175,6 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
-      - name: Restore dependencies cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-${{ env.ELIXIR_VERSION }}-
-            ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-
-            ${{ runner.os }}-mix-
-
-      - name: Install dependencies
-        run: mix deps.get
 
       - name: Build Hex package
         run: mix hex.build


### PR DESCRIPTION
## :bulb: Motivation and Context

Add CI coverage to ensure the Hex package can be built successfully. This helps catch packaging issues before release.

Changes:
- Added a dedicated `package` workflow job.
- Checks out the repository, sets up Elixir/OTP, and runs `mix hex.build`.


## :green_heart: How did you test it?

- [x] Ran `mix hex.build` locally.


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file
