### PR TITLE
feat: add enabled public API

### DIFF
--- a/lib/posthog.ex
+++ b/lib/posthog.ex
@@ -36,6 +36,25 @@ defmodule PostHog do
   @spec config(supervisor_name()) :: PostHog.Config.config()
   def config(name \\ __MODULE__), do: PostHog.Registry.config(name)
 
+  @doc """
+  Returns whether a named `PostHog` supervisor is enabled.
+
+  A supervisor is disabled when it was started without a configured API key. In
+  disabled mode, capture calls become no-ops.
+
+  ## Examples
+
+  Check the default `PostHog` instance:
+
+      PostHog.enabled?()
+
+  Check a named instance:
+
+      PostHog.enabled?(MyPostHog)
+  """
+  @spec enabled?(supervisor_name()) :: boolean()
+  def enabled?(name \\ __MODULE__), do: config(name).enabled
+
   @doc false
   def bare_capture(event, distinct_id, %{} = properties),
     do: bare_capture(__MODULE__, event, distinct_id, properties)

--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -21,6 +21,17 @@ defmodule PostHogTest do
     end
   end
 
+  describe "enabled?/1" do
+    test "returns true when the PostHog instance has an API key" do
+      assert PostHog.enabled?()
+    end
+
+    @tag config: [api_key: "", supervisor_name: DisabledPostHog]
+    test "returns false when the PostHog instance has no API key" do
+      refute PostHog.enabled?(DisabledPostHog)
+    end
+  end
+
   describe "bare_capture/4" do
     test "simple call" do
       PostHog.bare_capture("case tested", "distinct_id")


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds a small public API, `PostHog.enabled?/1`, so we can test the public API snapshot workflow added in #136.

Note: `public_api.snapshot` is intentionally not committed in this PR.

## :green_heart: How did you test it?

- `mix format`
- `mix test test/posthog_test.exs`
- `mix test`
- `mix posthog.public_api --check` (expected failure because the snapshot was intentionally not updated)

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->
