### PR TITLE
fix(handler): add synthetic logger stacktrace

### DIFF
--- a/.sampo/changesets/dashing-witch-aino.md
+++ b/.sampo/changesets/dashing-witch-aino.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Add source location stacktrace frames for plain Logger messages.

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -197,7 +197,59 @@ defmodule PostHog.Handler do
        ),
        do: %{stacktrace: do_stacktrace(stacktrace, in_app_modules)}
 
+  defp stacktrace(%{meta: meta}, in_app_modules) do
+    case synthetic_frame(meta, in_app_modules) do
+      nil -> %{}
+      frame -> %{stacktrace: %{type: "raw", frames: [frame]}}
+    end
+  end
+
   defp stacktrace(_event, _), do: %{}
+
+  defp synthetic_frame(%{line: line} = metadata, in_app_modules) when is_integer(line) do
+    {module, function, arity_or_args} = Map.get(metadata, :mfa, {nil, nil, nil})
+    filename = metadata |> Map.get(:file) |> safe_chardata_to_string()
+
+    with {:ok, function_name} <-
+           synthetic_function_name(module, function, arity_or_args, filename, line) do
+      %{
+        platform: "custom",
+        lang: "elixir",
+        function: function_name,
+        filename: filename,
+        lineno: line,
+        module: if(module, do: inspect(module)),
+        in_app: module in in_app_modules,
+        resolved: true,
+        synthetic: true
+      }
+    else
+      :error -> nil
+    end
+  end
+
+  defp synthetic_frame(_metadata, _in_app_modules), do: nil
+
+  defp synthetic_function_name(module, function, arity_or_args, _filename, line)
+       when is_atom(module) and is_atom(function) and
+              (is_integer(arity_or_args) or is_list(arity_or_args)) do
+    {:ok, "#{Exception.format_mfa(module, function, arity_or_args)}:#{line}"}
+  end
+
+  defp synthetic_function_name(_module, _function, _arity_or_args, filename, line)
+       when is_binary(filename) do
+    {:ok, "#{filename}:#{line}"}
+  end
+
+  defp synthetic_function_name(_module, _function, _arity_or_args, _filename, _line), do: :error
+
+  defp safe_chardata_to_string(nil), do: nil
+
+  defp safe_chardata_to_string(chardata) do
+    IO.chardata_to_string(chardata)
+  rescue
+    _ -> nil
+  end
 
   defp do_stacktrace([_ | _] = stacktrace, in_app_modules) do
     frames =

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -62,6 +62,46 @@ defmodule PostHog.HandlerTest do
            } = event
   end
 
+  test "adds synthetic stacktrace frame for plain logger messages", %{
+    handler_ref: ref,
+    config: %{supervisor_name: supervisor_name}
+  } do
+    expected_line = __ENV__.line + 1
+    Logger.info("Hello World")
+    LoggerHandlerKit.Assert.assert_logged(ref)
+
+    assert [event] = all_captured(supervisor_name)
+
+    assert %{
+             properties: %{
+               "$exception_list": [
+                 %{
+                   stacktrace: %{
+                     type: "raw",
+                     frames: [
+                       %{
+                         platform: "custom",
+                         lang: "elixir",
+                         filename: filename,
+                         function: function,
+                         lineno: ^expected_line,
+                         module: "PostHog.HandlerTest",
+                         in_app: false,
+                         resolved: true,
+                         synthetic: true
+                       }
+                     ]
+                   }
+                 }
+               ]
+             }
+           } = event
+
+    assert String.ends_with?(filename, "test/posthog/handler_test.exs")
+    assert String.contains?(function, "PostHog.HandlerTest")
+    assert String.ends_with?(function, ":#{expected_line}")
+  end
+
   @tag config: [capture_level: :warning]
   test "ignores messages lower than capture_level", %{
     handler_ref: ref,


### PR DESCRIPTION
## Summary
- add a synthetic stacktrace frame for plain Logger metadata with file/line details
- include module/function information when Logger metadata exposes MFA
- cover plain Logger messages with a handler test

## Tests
- mix test