### PR TITLE
fix(handler): add synthetic logger stacktrace

### DIFF
--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -14,4 +14,6 @@ jobs:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}
             is_draft: ${{ github.event.pull_request.draft }}
-        secrets: inherit
+        # The reusable workflow is pinned to a trusted PostHog/.github commit and needs
+        # the project-board bot secrets from this repository.
+        secrets: inherit # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit

--- a/.sampo/changesets/dashing-witch-aino.md
+++ b/.sampo/changesets/dashing-witch-aino.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Add source location stacktrace frames for plain Logger messages.

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -77,13 +77,7 @@ defmodule PostHog.Handler do
       initial_exception = exception(log_event, config)
 
       reporter_exception =
-        log_event
-        |> Map.update!(:meta, fn metadata ->
-          metadata
-          |> Map.delete(:crash_reason)
-          |> Map.put(:posthog_reporter, true)
-        end)
-        |> exception(config)
+        log_event |> Map.update!(:meta, &Map.delete(&1, :crash_reason)) |> exception(config)
 
       [initial_exception, reporter_exception]
     end
@@ -103,13 +97,7 @@ defmodule PostHog.Handler do
       initial_exception = exception(log_event, config)
 
       reporter_exception =
-        log_event
-        |> Map.update!(:meta, fn metadata ->
-          metadata
-          |> Map.delete(:crash_reason)
-          |> Map.put(:posthog_reporter, true)
-        end)
-        |> exception(config)
+        log_event |> Map.update!(:meta, &Map.delete(&1, :crash_reason)) |> exception(config)
 
       [reporter_exception, initial_exception]
     end
@@ -146,16 +134,6 @@ defmodule PostHog.Handler do
 
   defp do_type(%{meta: %{crash_reason: {reason, _}}}),
     do: Exception.format_banner(:exit, reason)
-
-  defp do_type(%{msg: {:string, chardata}, meta: %{error_logger: _}}),
-    do: IO.chardata_to_string(chardata)
-
-  defp do_type(%{msg: {:string, chardata}, meta: %{posthog_reporter: true}}),
-    do: IO.chardata_to_string(chardata)
-
-  defp do_type(%{level: level, msg: {:string, _}, meta: %{mfa: {_, _, _}, file: file, line: _}})
-       when is_binary(file) or is_list(file),
-       do: "Logger.#{level}"
 
   defp do_type(%{msg: {:string, chardata}}), do: IO.chardata_to_string(chardata)
 

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -203,7 +203,60 @@ defmodule PostHog.Handler do
        ),
        do: %{stacktrace: do_stacktrace(stacktrace, in_app_modules, config)}
 
+  defp stacktrace(%{meta: meta}, in_app_modules, config) do
+    case synthetic_frame(meta, in_app_modules, config) do
+      nil -> %{}
+      frame -> %{stacktrace: %{type: "raw", frames: [frame]}}
+    end
+  end
+
   defp stacktrace(_event, _, _), do: %{}
+
+  defp synthetic_frame(%{line: line} = metadata, in_app_modules, config) when is_integer(line) do
+    {module, function, arity_or_args} = Map.get(metadata, :mfa, {nil, nil, nil})
+    filename = metadata |> Map.get(:file) |> safe_chardata_to_string()
+
+    with {:ok, function_name} <-
+           synthetic_function_name(module, function, arity_or_args, filename, line) do
+      %{
+        platform: "custom",
+        lang: "elixir",
+        function: function_name,
+        filename: filename,
+        lineno: line,
+        module: if(module, do: inspect(module)),
+        in_app: module in in_app_modules,
+        resolved: true,
+        synthetic: true
+      }
+      |> maybe_add_source_context(filename, line, config)
+    else
+      :error -> nil
+    end
+  end
+
+  defp synthetic_frame(_metadata, _in_app_modules, _config), do: nil
+
+  defp synthetic_function_name(module, function, arity_or_args, _filename, line)
+       when is_atom(module) and is_atom(function) and
+              (is_integer(arity_or_args) or is_list(arity_or_args)) do
+    {:ok, "#{Exception.format_mfa(module, function, arity_or_args)}:#{line}"}
+  end
+
+  defp synthetic_function_name(_module, _function, _arity_or_args, filename, line)
+       when is_binary(filename) do
+    {:ok, "#{filename}:#{line}"}
+  end
+
+  defp synthetic_function_name(_module, _function, _arity_or_args, _filename, _line), do: :error
+
+  defp safe_chardata_to_string(nil), do: nil
+
+  defp safe_chardata_to_string(chardata) do
+    IO.chardata_to_string(chardata)
+  rescue
+    _ -> nil
+  end
 
   defp do_stacktrace([_ | _] = stacktrace, in_app_modules, config) do
     frames =

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -216,22 +216,23 @@ defmodule PostHog.Handler do
     {module, function, arity_or_args} = Map.get(metadata, :mfa, {nil, nil, nil})
     filename = metadata |> Map.get(:file) |> safe_chardata_to_string()
 
-    with {:ok, function_name} <-
-           synthetic_function_name(module, function, arity_or_args, filename, line) do
-      %{
-        platform: "custom",
-        lang: "elixir",
-        function: function_name,
-        filename: filename,
-        lineno: line,
-        module: if(module, do: inspect(module)),
-        in_app: module in in_app_modules,
-        resolved: true,
-        synthetic: true
-      }
-      |> maybe_add_source_context(filename, line, config)
-    else
-      :error -> nil
+    case synthetic_function_name(module, function, arity_or_args, filename, line) do
+      {:ok, function_name} ->
+        %{
+          platform: "custom",
+          lang: "elixir",
+          function: function_name,
+          filename: filename,
+          lineno: line,
+          module: if(module, do: inspect(module)),
+          in_app: module in in_app_modules,
+          resolved: true,
+          synthetic: true
+        }
+        |> maybe_add_source_context(filename, line, config)
+
+      :error ->
+        nil
     end
   end
 

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -216,7 +216,7 @@ defmodule PostHog.Handler do
       %{
         platform: "custom",
         lang: "elixir",
-        function: "#{Exception.format_mfa(module, function, arity_or_args)}:#{line}",
+        function: Exception.format_mfa(module, function, arity_or_args),
         filename: filename,
         lineno: line,
         module: inspect(module),

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -77,7 +77,13 @@ defmodule PostHog.Handler do
       initial_exception = exception(log_event, config)
 
       reporter_exception =
-        log_event |> Map.update!(:meta, &reporter_metadata/1) |> exception(config)
+        log_event
+        |> Map.update!(:meta, fn metadata ->
+          metadata
+          |> Map.delete(:crash_reason)
+          |> Map.put(:posthog_reporter, true)
+        end)
+        |> exception(config)
 
       [initial_exception, reporter_exception]
     end
@@ -97,7 +103,13 @@ defmodule PostHog.Handler do
       initial_exception = exception(log_event, config)
 
       reporter_exception =
-        log_event |> Map.update!(:meta, &reporter_metadata/1) |> exception(config)
+        log_event
+        |> Map.update!(:meta, fn metadata ->
+          metadata
+          |> Map.delete(:crash_reason)
+          |> Map.put(:posthog_reporter, true)
+        end)
+        |> exception(config)
 
       [reporter_exception, initial_exception]
     end
@@ -105,12 +117,6 @@ defmodule PostHog.Handler do
 
   defp exceptions(log_event, config) do
     [exception(log_event, config)]
-  end
-
-  defp reporter_metadata(metadata) do
-    metadata
-    |> Map.delete(:crash_reason)
-    |> Map.put(:posthog_reporter, true)
   end
 
   defp exception(log_event, config) do

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -203,61 +203,32 @@ defmodule PostHog.Handler do
        ),
        do: %{stacktrace: do_stacktrace(stacktrace, in_app_modules, config)}
 
-  defp stacktrace(%{meta: meta}, in_app_modules, config) do
-    case synthetic_frame(meta, in_app_modules, config) do
-      nil -> %{}
-      frame -> %{stacktrace: %{type: "raw", frames: [frame]}}
-    end
+  defp stacktrace(
+         %{meta: %{mfa: {module, function, arity_or_args}, file: file, line: line}},
+         in_app_modules,
+         config
+       )
+       when is_binary(file) or is_list(file) do
+    filename = IO.chardata_to_string(file)
+
+    frame =
+      %{
+        platform: "custom",
+        lang: "elixir",
+        function: "#{Exception.format_mfa(module, function, arity_or_args)}:#{line}",
+        filename: filename,
+        lineno: line,
+        module: inspect(module),
+        in_app: module in in_app_modules,
+        resolved: true,
+        synthetic: true
+      }
+      |> maybe_add_source_context(filename, line, config)
+
+    %{stacktrace: %{type: "raw", frames: [frame]}}
   end
 
   defp stacktrace(_event, _, _), do: %{}
-
-  defp synthetic_frame(%{line: line} = metadata, in_app_modules, config) when is_integer(line) do
-    {module, function, arity_or_args} = Map.get(metadata, :mfa, {nil, nil, nil})
-    filename = metadata |> Map.get(:file) |> safe_chardata_to_string()
-
-    case synthetic_function_name(module, function, arity_or_args, filename, line) do
-      {:ok, function_name} ->
-        %{
-          platform: "custom",
-          lang: "elixir",
-          function: function_name,
-          filename: filename,
-          lineno: line,
-          module: if(module, do: inspect(module)),
-          in_app: module in in_app_modules,
-          resolved: true,
-          synthetic: true
-        }
-        |> maybe_add_source_context(filename, line, config)
-
-      :error ->
-        nil
-    end
-  end
-
-  defp synthetic_frame(_metadata, _in_app_modules, _config), do: nil
-
-  defp synthetic_function_name(module, function, arity_or_args, _filename, line)
-       when is_atom(module) and is_atom(function) and
-              (is_integer(arity_or_args) or is_list(arity_or_args)) do
-    {:ok, "#{Exception.format_mfa(module, function, arity_or_args)}:#{line}"}
-  end
-
-  defp synthetic_function_name(_module, _function, _arity_or_args, filename, line)
-       when is_binary(filename) do
-    {:ok, "#{filename}:#{line}"}
-  end
-
-  defp synthetic_function_name(_module, _function, _arity_or_args, _filename, _line), do: :error
-
-  defp safe_chardata_to_string(nil), do: nil
-
-  defp safe_chardata_to_string(chardata) do
-    IO.chardata_to_string(chardata)
-  rescue
-    _ -> nil
-  end
 
   defp do_stacktrace([_ | _] = stacktrace, in_app_modules, config) do
     frames =

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -209,7 +209,8 @@ defmodule PostHog.Handler do
          config
        )
        when is_binary(file) or is_list(file) do
-    filename = IO.chardata_to_string(file)
+    filename =
+      file |> IO.chardata_to_string() |> normalize_source_filename(config.root_source_code_paths)
 
     frame =
       %{
@@ -229,6 +230,22 @@ defmodule PostHog.Handler do
   end
 
   defp stacktrace(_event, _, _), do: %{}
+
+  defp normalize_source_filename(filename, root_paths) do
+    relative_to_source_root =
+      root_paths
+      |> Enum.map(&Path.expand/1)
+      |> Enum.sort_by(&String.length/1, :desc)
+      |> Enum.find_value(fn root ->
+        relative = Path.relative_to(filename, root)
+
+        if relative != filename do
+          relative
+        end
+      end)
+
+    relative_to_source_root || Path.relative_to_cwd(filename)
+  end
 
   defp do_stacktrace([_ | _] = stacktrace, in_app_modules, config) do
     frames =

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -77,7 +77,7 @@ defmodule PostHog.Handler do
       initial_exception = exception(log_event, config)
 
       reporter_exception =
-        log_event |> Map.update!(:meta, &Map.delete(&1, :crash_reason)) |> exception(config)
+        log_event |> Map.update!(:meta, &reporter_metadata/1) |> exception(config)
 
       [initial_exception, reporter_exception]
     end
@@ -97,7 +97,7 @@ defmodule PostHog.Handler do
       initial_exception = exception(log_event, config)
 
       reporter_exception =
-        log_event |> Map.update!(:meta, &Map.delete(&1, :crash_reason)) |> exception(config)
+        log_event |> Map.update!(:meta, &reporter_metadata/1) |> exception(config)
 
       [reporter_exception, initial_exception]
     end
@@ -105,6 +105,12 @@ defmodule PostHog.Handler do
 
   defp exceptions(log_event, config) do
     [exception(log_event, config)]
+  end
+
+  defp reporter_metadata(metadata) do
+    metadata
+    |> Map.delete(:crash_reason)
+    |> Map.put(:posthog_reporter, true)
   end
 
   defp exception(log_event, config) do
@@ -134,6 +140,16 @@ defmodule PostHog.Handler do
 
   defp do_type(%{meta: %{crash_reason: {reason, _}}}),
     do: Exception.format_banner(:exit, reason)
+
+  defp do_type(%{msg: {:string, chardata}, meta: %{error_logger: _}}),
+    do: IO.chardata_to_string(chardata)
+
+  defp do_type(%{msg: {:string, chardata}, meta: %{posthog_reporter: true}}),
+    do: IO.chardata_to_string(chardata)
+
+  defp do_type(%{level: level, msg: {:string, _}, meta: %{mfa: {_, _, _}, file: file, line: _}})
+       when is_binary(file) or is_list(file),
+       do: "Logger.#{level}"
 
   defp do_type(%{msg: {:string, chardata}}), do: IO.chardata_to_string(chardata)
 

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -66,8 +66,7 @@ defmodule PostHog.HandlerTest do
     handler_ref: ref,
     config: %{supervisor_name: supervisor_name}
   } do
-    expected_line = __ENV__.line + 1
-    Logger.info("Hello World")
+    expected_line = log_plain_message()
     LoggerHandlerKit.Assert.assert_logged(ref)
 
     assert [event] = all_captured(supervisor_name)
@@ -98,9 +97,13 @@ defmodule PostHog.HandlerTest do
            } = event
 
     assert filename == "test/posthog/handler_test.exs"
+    assert function == "PostHog.HandlerTest.log_plain_message/0"
+  end
 
-    assert function ==
-             "PostHog.HandlerTest.\"test adds synthetic stacktrace frame for plain logger messages\"/1"
+  defp log_plain_message do
+    expected_line = __ENV__.line + 1
+    Logger.info("Hello World")
+    expected_line
   end
 
   @tag config: [capture_level: :warning]

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -99,7 +99,7 @@ defmodule PostHog.HandlerTest do
 
     assert filename == "test/posthog/handler_test.exs"
     assert String.contains?(function, "PostHog.HandlerTest")
-    assert String.ends_with?(function, ":#{expected_line}")
+    refute String.ends_with?(function, ":#{expected_line}")
   end
 
   @tag config: [capture_level: :warning]

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -25,7 +25,7 @@ defmodule PostHog.HandlerTest do
              properties: %{
                "$exception_list": [
                  %{
-                   type: "Hello World",
+                   type: "Logger.info",
                    value: "Hello World",
                    mechanism: %{handled: true, type: "generic"}
                  }
@@ -53,7 +53,7 @@ defmodule PostHog.HandlerTest do
                foo: "bar",
                "$exception_list": [
                  %{
-                   type: "Hello World",
+                   type: "Logger.info",
                    value: "Hello World",
                    mechanism: %{handled: true, type: "generic"}
                  }
@@ -75,6 +75,8 @@ defmodule PostHog.HandlerTest do
              properties: %{
                "$exception_list": [
                  %{
+                   type: "Logger.info",
+                   value: "Hello World",
                    stacktrace: %{
                      type: "raw",
                      frames: [
@@ -1531,7 +1533,7 @@ defmodule PostHog.HandlerTest do
                extra: "Foo",
                "$exception_list": [
                  %{
-                   type: "Error with metadata",
+                   type: "Logger.error",
                    value: "Error with metadata",
                    mechanism: %{handled: true}
                  }
@@ -1562,7 +1564,7 @@ defmodule PostHog.HandlerTest do
                  should: "work",
                  "$exception_list": [
                    %{
-                     type: "Error with metadata",
+                     type: "Logger.error",
                      value: "Error with metadata",
                      mechanism: %{handled: true}
                    }
@@ -1651,7 +1653,7 @@ defmodule PostHog.HandlerTest do
                foo: "bar",
                "$exception_list": [
                  %{
-                   type: "Error with metadata",
+                   type: "Logger.error",
                    value: "Error with metadata",
                    mechanism: %{handled: true, type: "generic"}
                  }

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -25,7 +25,7 @@ defmodule PostHog.HandlerTest do
              properties: %{
                "$exception_list": [
                  %{
-                   type: "Logger.info",
+                   type: "Hello World",
                    value: "Hello World",
                    mechanism: %{handled: true, type: "generic"}
                  }
@@ -53,7 +53,7 @@ defmodule PostHog.HandlerTest do
                foo: "bar",
                "$exception_list": [
                  %{
-                   type: "Logger.info",
+                   type: "Hello World",
                    value: "Hello World",
                    mechanism: %{handled: true, type: "generic"}
                  }
@@ -75,7 +75,7 @@ defmodule PostHog.HandlerTest do
              properties: %{
                "$exception_list": [
                  %{
-                   type: "Logger.info",
+                   type: "Hello World",
                    value: "Hello World",
                    stacktrace: %{
                      type: "raw",
@@ -1533,7 +1533,7 @@ defmodule PostHog.HandlerTest do
                extra: "Foo",
                "$exception_list": [
                  %{
-                   type: "Logger.error",
+                   type: "Error with metadata",
                    value: "Error with metadata",
                    mechanism: %{handled: true}
                  }
@@ -1564,7 +1564,7 @@ defmodule PostHog.HandlerTest do
                  should: "work",
                  "$exception_list": [
                    %{
-                     type: "Logger.error",
+                     type: "Error with metadata",
                      value: "Error with metadata",
                      mechanism: %{handled: true}
                    }
@@ -1653,7 +1653,7 @@ defmodule PostHog.HandlerTest do
                foo: "bar",
                "$exception_list": [
                  %{
-                   type: "Logger.error",
+                   type: "Error with metadata",
                    value: "Error with metadata",
                    mechanism: %{handled: true, type: "generic"}
                  }

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -97,7 +97,7 @@ defmodule PostHog.HandlerTest do
              }
            } = event
 
-    assert String.ends_with?(filename, "test/posthog/handler_test.exs")
+    assert filename == "test/posthog/handler_test.exs"
     assert String.contains?(function, "PostHog.HandlerTest")
     assert String.ends_with?(function, ":#{expected_line}")
   end

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -62,6 +62,46 @@ defmodule PostHog.HandlerTest do
            } = event
   end
 
+  test "adds synthetic stacktrace frame for plain logger messages", %{
+    handler_ref: ref,
+    config: %{supervisor_name: supervisor_name}
+  } do
+    expected_line = __ENV__.line + 1
+    Logger.info("Hello World")
+    LoggerHandlerKit.Assert.assert_logged(ref)
+
+    assert [event] = all_captured(supervisor_name)
+
+    assert %{
+             properties: %{
+               "$exception_list": [
+                 %{
+                   stacktrace: %{
+                     type: "raw",
+                     frames: [
+                       %{
+                         platform: "custom",
+                         lang: "elixir",
+                         filename: filename,
+                         function: function,
+                         lineno: ^expected_line,
+                         module: "PostHog.HandlerTest",
+                         in_app: false,
+                         resolved: true,
+                         synthetic: true
+                       }
+                     ]
+                   }
+                 }
+               ]
+             }
+           } = event
+
+    assert String.ends_with?(filename, "test/posthog/handler_test.exs")
+    assert String.contains?(function, "PostHog.HandlerTest")
+    assert String.ends_with?(function, ":#{expected_line}")
+  end
+
   @tag config: [capture_level: :warning]
   test "ignores messages lower than capture_level", %{
     handler_ref: ref,

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -98,8 +98,9 @@ defmodule PostHog.HandlerTest do
            } = event
 
     assert filename == "test/posthog/handler_test.exs"
-    assert String.contains?(function, "PostHog.HandlerTest")
-    refute String.ends_with?(function, ":#{expected_line}")
+
+    assert function ==
+             "PostHog.HandlerTest.\"test adds synthetic stacktrace frame for plain logger messages\"/1"
   end
 
   @tag config: [capture_level: :warning]


### PR DESCRIPTION
## :bulb: Motivation and Context
Plain Logger messages do not have exception stacktraces, but Logger metadata includes source location information. This adds a synthetic single-frame stacktrace from Logger metadata so error tracking can point plain log messages back to their file, line, and function.


## :green_heart: How did you test it?

- `mix test`


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi/coding-agent assistance. The change reuses Logger event metadata (`file`, `line`, and `mfa`) to create a synthetic raw stacktrace frame only when a real exception stacktrace is absent, and keeps source context enrichment compatible with the current main branch.