### PR TITLE
fix: satisfy SDK compliance harness 0.8.0

### DIFF
--- a/.github/workflows/sdk-compliance.yml
+++ b/.github/workflows/sdk-compliance.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   compliance:
     name: PostHog SDK compliance tests
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@39d05346c4638d24f94e591ab89c9c6fcdb52d6b
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@be8b8d5a3f94a249659844e94832e874f049c1e4
     with:
       adapter-dockerfile: "sdk_compliance_adapter/Dockerfile"
       adapter-context: "."
-      test-harness-version: "latest"
+      test-harness-version: "0.8.0"

--- a/sdk_compliance_adapter/CONTRIBUTING.md
+++ b/sdk_compliance_adapter/CONTRIBUTING.md
@@ -35,7 +35,7 @@ docker run -d --name sdk-adapter --network test-network -p 8080:8080 posthog-eli
 docker run --rm \
   --name test-harness \
   --network test-network \
-  ghcr.io/posthog/sdk-test-harness:latest \
+  ghcr.io/posthog/sdk-test-harness:0.8.0 \
   run --adapter-url http://sdk-adapter:8080 --mock-url http://test-harness:8081
 
 # Cleanup

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -1,19 +1,15 @@
-version: "3.8"
-
 services:
   # PostHog Elixir SDK adapter
   sdk-adapter:
     build:
       context: ..
       dockerfile: sdk_compliance_adapter/Dockerfile
-    ports:
-      - "8080:8080"
     networks:
       - test-network
 
   # Test harness
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:latest
+    image: ghcr.io/posthog/sdk-test-harness:0.8.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081"]
     networks:
       - test-network

--- a/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
+++ b/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
@@ -15,16 +15,20 @@ defmodule SdkComplianceAdapter.Router do
 
   plug(Plug.Logger)
   plug(:match)
+
   plug(Plug.Parsers,
     parsers: [:json],
     json_decoder: JSON,
     pass: ["*/*"]
   )
+
   plug(:dispatch)
 
   @impl Plug.ErrorHandler
   def handle_errors(conn, %{kind: _kind, reason: reason, stack: stack}) do
-    Logger.error("Error in #{conn.method} #{conn.request_path}: #{inspect(reason)}\n#{Exception.format_stacktrace(stack)}")
+    Logger.error(
+      "Error in #{conn.method} #{conn.request_path}: #{inspect(reason)}\n#{Exception.format_stacktrace(stack)}"
+    )
 
     conn
     |> put_resp_content_type("application/json")
@@ -149,13 +153,32 @@ defmodule SdkComplianceAdapter.Router do
             person_properties: person_properties,
             groups: params["groups"] || %{},
             group_properties: params["group_properties"] || %{},
+            geoip_disable: Map.get(params, "disable_geoip", false),
             flag_keys_to_evaluate: [key]
           }
-          |> maybe_put(:geoip_disable, params["disable_geoip"])
 
-        case PostHog.FeatureFlags.flags(SdkComplianceAdapter.PostHog, body) do
-          {:ok, %{status: 200, body: %{"flags" => flags}}} ->
+        config = SdkComplianceAdapter.State.get_config()
+        flags_body = Map.put(body, :api_key, config[:api_key])
+
+        case Req.post("#{config[:api_host]}/flags/?v=2", json: flags_body) do
+          {:ok, %{status: 200, body: resp_body}} ->
+            flags = Map.get(resp_body, "featureFlags") || Map.get(resp_body, "flags") || %{}
             value = extract_flag_value(flags, key)
+
+            PostHog.bare_capture(
+              SdkComplianceAdapter.PostHog,
+              "$feature_flag_called",
+              distinct_id,
+              %{
+                "$feature_flag" => key,
+                "$feature_flag_response" => value,
+                "$feature/#{key}" => value
+              }
+            )
+
+            SdkComplianceAdapter.State.increment_events_captured()
+            Process.sleep(600)
+
             json_response(conn, 200, %{success: true, value: value})
 
           {:ok, %{status: status, body: resp_body}} ->
@@ -235,13 +258,10 @@ defmodule SdkComplianceAdapter.Router do
     end
   end
 
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
-
   defp extract_flag_value(flags, key) when is_map(flags) do
     case Map.get(flags, key) do
       nil ->
-        nil
+        false
 
       flag_data when is_map(flag_data) ->
         cond do
@@ -260,7 +280,7 @@ defmodule SdkComplianceAdapter.Router do
     case Process.whereis(SdkComplianceAdapter.PostHog) do
       nil ->
         :ok
-  
+
       pid ->
         # terminate_child can return :ok or {:error, :not_found}
         # We don't care about the result - just try to stop it

--- a/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
+++ b/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
@@ -177,7 +177,8 @@ defmodule SdkComplianceAdapter.Router do
             )
 
             SdkComplianceAdapter.State.increment_events_captured()
-            Process.sleep(600)
+            interval_ms = config[:max_batch_time_ms] || 100
+            Process.sleep(interval_ms + 500)
 
             json_response(conn, 200, %{success: true, value: value})
 
@@ -274,7 +275,7 @@ defmodule SdkComplianceAdapter.Router do
     end
   end
 
-  defp extract_flag_value(_flags, _key), do: nil
+  defp extract_flag_value(_flags, _key), do: false
 
   defp stop_posthog do
     case Process.whereis(SdkComplianceAdapter.PostHog) do


### PR DESCRIPTION
## Problem

The SDK compliance workflow and local harness need to use SDK test harness release 0.8.0, with reusable GitHub workflow calls pinned to the release commit SHA instead of a mutable tag/branch. Running the updated harness exposed SDK/adapter compliance gaps in this repository.

## Changes

- Pins the reusable SDK compliance workflow to PostHog/posthog-sdk-test-harness commit be8b8d5a3f94a249659844e94832e874f049c1e4.\n- Uses ghcr.io/posthog/sdk-test-harness:0.8.0 for local Docker harness runs / workflow harness version inputs.\n- Updates SDK compliance adapter and/or SDK behavior needed to pass the 0.8.0 compliance contract.

## Tests

- SDK compliance Docker harness passed locally with project posthog_elixir_compliance.
