### PR TITLE
fix: fall back when payload compression fails

### DIFF
--- a/.sampo/changesets/ardent-king-kalma.md
+++ b/.sampo/changesets/ardent-king-kalma.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Fall back to uncompressed API requests when gzip compression fails

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -185,26 +185,23 @@ defmodule PostHog.API.Client do
     |> request_with_compression_fallback()
   end
 
-  defp request_with_compression_fallback(req) do
-    Req.request(req)
-  rescue
-    exception ->
-      if compression_failure?(req, __STACKTRACE__) do
-        req
-        |> Req.merge(compress_body: false)
-        |> Req.request()
-      else
-        reraise exception, __STACKTRACE__
-      end
+  @doc false
+  def request_with_compression_fallback_for_test(req, request_fun) do
+    request_with_compression_fallback(req, request_fun)
   end
 
-  defp compression_failure?(req, stacktrace) do
-    Req.Request.fetch_option(req, :compress_body) == {:ok, true} &&
-      Enum.any?(stacktrace, fn
-        {Req.Steps, :compress_body, _, _} -> true
-        {:zlib, :gzip, _, _} -> true
-        {Req.Utils, :stream_gzip, _, _} -> true
-        _ -> false
-      end)
+  defp request_with_compression_fallback(req, request_fun \\ &Req.request/1) do
+    request_fun.(req)
+  rescue
+    exception ->
+      case Req.Request.fetch_option(req, :compress_body) do
+        {:ok, true} ->
+          req
+          |> Req.merge(compress_body: false)
+          |> request_fun.()
+
+        _ ->
+          reraise exception, __STACKTRACE__
+      end
   end
 end

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -185,11 +185,6 @@ defmodule PostHog.API.Client do
     |> request_with_compression_fallback()
   end
 
-  @doc false
-  def request_with_compression_fallback_for_test(req) do
-    request_with_compression_fallback(req)
-  end
-
   defp request_with_compression_fallback(req) do
     req
     |> with_compression_fallback_step()

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -186,22 +186,28 @@ defmodule PostHog.API.Client do
   end
 
   @doc false
-  def request_with_compression_fallback_for_test(req, request_fun) do
-    request_with_compression_fallback(req, request_fun)
+  def request_with_compression_fallback_for_test(req) do
+    request_with_compression_fallback(req)
   end
 
-  defp request_with_compression_fallback(req, request_fun \\ &Req.request/1) do
-    request_fun.(req)
-  rescue
-    exception ->
-      case Req.Request.fetch_option(req, :compress_body) do
-        {:ok, true} ->
-          req
-          |> Req.merge(compress_body: false)
-          |> request_fun.()
+  defp request_with_compression_fallback(req) do
+    req
+    |> with_compression_fallback_step()
+    |> Req.request()
+  end
 
-        _ ->
-          reraise exception, __STACKTRACE__
-      end
+  defp with_compression_fallback_step(req) do
+    %{
+      req
+      | request_steps:
+          Keyword.replace(req.request_steps, :compress_body, &compress_body_with_fallback/1)
+    }
+  end
+
+  defp compress_body_with_fallback(req) do
+    Req.Steps.compress_body(req)
+  rescue
+    _exception ->
+      Req.merge(req, compress_body: false)
   end
 end

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -182,6 +182,29 @@ defmodule PostHog.API.Client do
           req
       end
     end)
-    |> Req.request()
+    |> request_with_compression_fallback()
+  end
+
+  defp request_with_compression_fallback(req) do
+    Req.request(req)
+  rescue
+    exception ->
+      if compression_failure?(req, __STACKTRACE__) do
+        req
+        |> Req.merge(compress_body: false)
+        |> Req.request()
+      else
+        reraise exception, __STACKTRACE__
+      end
+  end
+
+  defp compression_failure?(req, stacktrace) do
+    Req.Request.fetch_option(req, :compress_body) == {:ok, true} &&
+      Enum.any?(stacktrace, fn
+        {Req.Steps, :compress_body, _, _} -> true
+        {:zlib, :gzip, _, _} -> true
+        {Req.Utils, :stream_gzip, _, _} -> true
+        _ -> false
+      end)
   end
 end

--- a/test/posthog/api/client_test.exs
+++ b/test/posthog/api/client_test.exs
@@ -27,7 +27,7 @@ defmodule PostHog.API.ClientTest do
         end
       )
 
-    assert {:ok, %{status: 200}} = Client.request_with_compression_fallback_for_test(req)
+    assert {:ok, %{status: 200}} = Client.request(req, :post, "/", [])
     assert_received {:request, {:ok, false}, []}
   end
 
@@ -45,7 +45,7 @@ defmodule PostHog.API.ClientTest do
       )
 
     assert_raise RuntimeError, "request failed", fn ->
-      Client.request_with_compression_fallback_for_test(req)
+      Client.request(req, :post, "/", [])
     end
 
     assert Agent.get(calls, & &1) == 1
@@ -64,7 +64,7 @@ defmodule PostHog.API.ClientTest do
         end
       )
 
-    assert {:ok, %{status: 200}} = Client.request_with_compression_fallback_for_test(req)
+    assert {:ok, %{status: 200}} = Client.request(req, :post, "/", [])
     assert_received {:request, ["gzip"], gzipped_body}
     assert :zlib.gunzip(gzipped_body) == "hello"
   end

--- a/test/posthog/api/client_test.exs
+++ b/test/posthog/api/client_test.exs
@@ -9,32 +9,63 @@ defmodule PostHog.API.ClientTest do
     assert req.headers["user-agent"] == [Client.user_agent()]
   end
 
-  test "request fallback retries without compression when compressed request raises" do
-    req = Req.new(compress_body: true)
-    {:ok, calls} = Agent.start_link(fn -> [] end)
+  test "request fallback continues uncompressed when compression step raises" do
+    parent = self()
 
-    request_fun = fn req ->
-      Agent.update(calls, &[Req.Request.fetch_option(req, :compress_body) | &1])
+    req =
+      Req.new(
+        body: [123_456],
+        compress_body: true,
+        adapter: fn req ->
+          send(
+            parent,
+            {:request, Req.Request.fetch_option(req, :compress_body),
+             Req.Request.get_header(req, "content-encoding")}
+          )
 
-      case Req.Request.fetch_option(req, :compress_body) do
-        {:ok, true} -> raise RuntimeError, "gzip failed"
-        {:ok, false} -> {:ok, %{status: 200, body: %{}}}
-      end
-    end
+          {req, Req.Response.new(status: 200, body: %{})}
+        end
+      )
 
-    assert {:ok, %{status: 200}} =
-             Client.request_with_compression_fallback_for_test(req, request_fun)
-
-    assert Agent.get(calls, &Enum.reverse/1) == [{:ok, true}, {:ok, false}]
+    assert {:ok, %{status: 200}} = Client.request_with_compression_fallback_for_test(req)
+    assert_received {:request, {:ok, false}, []}
   end
 
-  test "request fallback reraises when compression is disabled" do
-    req = Req.new(compress_body: false)
+  test "request fallback does not catch adapter exceptions" do
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    req =
+      Req.new(
+        body: "ok",
+        compress_body: true,
+        adapter: fn _req ->
+          Agent.update(calls, &(&1 + 1))
+          raise RuntimeError, "request failed"
+        end
+      )
 
     assert_raise RuntimeError, "request failed", fn ->
-      Client.request_with_compression_fallback_for_test(req, fn _req ->
-        raise RuntimeError, "request failed"
-      end)
+      Client.request_with_compression_fallback_for_test(req)
     end
+
+    assert Agent.get(calls, & &1) == 1
+  end
+
+  test "request fallback preserves normal compression" do
+    parent = self()
+
+    req =
+      Req.new(
+        body: "hello",
+        compress_body: true,
+        adapter: fn req ->
+          send(parent, {:request, Req.Request.get_header(req, "content-encoding"), req.body})
+          {req, Req.Response.new(status: 200, body: %{})}
+        end
+      )
+
+    assert {:ok, %{status: 200}} = Client.request_with_compression_fallback_for_test(req)
+    assert_received {:request, ["gzip"], gzipped_body}
+    assert :zlib.gunzip(gzipped_body) == "hello"
   end
 end

--- a/test/posthog/api/client_test.exs
+++ b/test/posthog/api/client_test.exs
@@ -8,4 +8,33 @@ defmodule PostHog.API.ClientTest do
 
     assert req.headers["user-agent"] == [Client.user_agent()]
   end
+
+  test "request fallback retries without compression when compressed request raises" do
+    req = Req.new(compress_body: true)
+    {:ok, calls} = Agent.start_link(fn -> [] end)
+
+    request_fun = fn req ->
+      Agent.update(calls, &[Req.Request.fetch_option(req, :compress_body) | &1])
+
+      case Req.Request.fetch_option(req, :compress_body) do
+        {:ok, true} -> raise RuntimeError, "gzip failed"
+        {:ok, false} -> {:ok, %{status: 200, body: %{}}}
+      end
+    end
+
+    assert {:ok, %{status: 200}} =
+             Client.request_with_compression_fallback_for_test(req, request_fun)
+
+    assert Agent.get(calls, &Enum.reverse/1) == [{:ok, true}, {:ok, false}]
+  end
+
+  test "request fallback reraises when compression is disabled" do
+    req = Req.new(compress_body: false)
+
+    assert_raise RuntimeError, "request failed", fn ->
+      Client.request_with_compression_fallback_for_test(req, fn _req ->
+        raise RuntimeError, "request failed"
+      end)
+    end
+  end
 end


### PR DESCRIPTION
## :bulb: Motivation and Context

The default Req-backed client enables gzip request-body compression. If that local compression step fails, the SDK should retry the request uncompressed instead of failing before the request is sent.

This wraps the default request execution and retries once with `compress_body: false` only when the failure stack indicates Req's compression step.

## :green_heart: How did you test it?

- `mix test test/posthog/api/client_test.exs`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented as part of a cross-SDK consistency pass for client-side compression failure fallback. The fallback is limited to compression-step failures so unrelated request exceptions still surface normally.
