### PR TITLE
fix: require safe Req versions

### DIFF
--- a/.sampo/changesets/heroic-queen-marjatta.md
+++ b/.sampo/changesets/heroic-queen-marjatta.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Require Req 0.6.1 or newer to avoid vulnerable 0.5.x and 0.6.0 releases.

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule PostHog.MixProject do
   defp deps do
     [
       {:nimble_options, "~> 1.1"},
-      {:req, "~> 0.5"},
+      {:req, ">= 0.6.1 and < 1.0.0"},
       {:logger_json, "~> 7.0"},
       {:nimble_ownership, "~> 1.0"},
       {:uuid_v7, "~> 0.6"},


### PR DESCRIPTION
## :bulb: Motivation and Context

Req has security fixes available in the 0.6 line:

- https://nvd.nist.gov/vuln/detail/CVE-2026-49756
- https://nvd.nist.gov/vuln/detail/CVE-2026-49755

The SDK dependency constraint still allowed affected Req releases. This tightens the minimum to `>= 0.6.1` while preserving the previous `< 1.0.0` upper bound, so downstream projects resolve to a fixed Req version without narrowing future compatible 0.x releases unnecessarily.

Also adds a patch Sampo changeset for the release notes.

## :green_heart: How did you test it?

- `mix deps.get`
- `mix test`
- `mix format --check-formatted`
- `mix compile --warnings-as-errors && mix posthog.public_api --check`
- `mix credo --strict`
- `mix hex.build`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi made the scoped dependency metadata change and generated the Sampo changeset. A reviewer subagent checked the diff; based on that review, the lockfile was left unchanged because it already uses Req 0.6.1 and extra transitive dependency churn was unnecessary.
