### PR TITLE
fix(handler): group captured log messages by call site, not message content

### DIFF
--- a/.sampo/changesets/grouping-log-call-site.md
+++ b/.sampo/changesets/grouping-log-call-site.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Group captured log messages by logging call site instead of message content. Plain log messages often interpolate dynamic values (ids, URLs, inspected terms), and using the message as the exception type created a separate error tracking issue for every distinct message. The exception type is now `Logger <level> (<Module.function/arity>)` when call-site metadata is available; the full message remains in the exception value.

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -98,8 +98,15 @@ defmodule PostHog.Handler do
     defp exceptions(%{meta: %{crash_reason: _}} = log_event, config) do
       initial_exception = exception(log_event, config)
 
+      # Mark the copy so `do_type/1` keeps the message-derived type here: this
+      # entry names the issue, and the attached crash usually explains it better
+      # than the logging call site would.
       reporter_exception =
-        log_event |> Map.update!(:meta, &Map.delete(&1, :crash_reason)) |> exception(config)
+        log_event
+        |> Map.update!(:meta, fn meta ->
+          meta |> Map.delete(:crash_reason) |> Map.put(:__posthog_crash_reporter__, true)
+        end)
+        |> exception(config)
 
       [reporter_exception, initial_exception]
     end
@@ -136,6 +143,14 @@ defmodule PostHog.Handler do
 
   defp do_type(%{meta: %{crash_reason: {reason, _}}}),
     do: Exception.format_banner(:exit, reason)
+
+  # Plain log messages usually interpolate dynamic values (ids, URLs, inspected
+  # terms), which makes the message itself a poor grouping key: error tracking
+  # would create a separate issue for every distinct message. Key the type on the
+  # logging call site instead; the full message is still available in `value`.
+  defp do_type(%{level: level, msg: {:string, _}, meta: %{mfa: {module, function, arity}} = meta})
+       when not is_map_key(meta, :__posthog_crash_reporter__),
+       do: "Logger #{level} (#{Exception.format_mfa(module, function, arity)})"
 
   defp do_type(%{msg: {:string, chardata}}), do: IO.chardata_to_string(chardata)
 

--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -148,7 +148,14 @@ defmodule PostHog.Handler do
   # terms), which makes the message itself a poor grouping key: error tracking
   # would create a separate issue for every distinct message. Key the type on the
   # logging call site instead; the full message is still available in `value`.
-  defp do_type(%{level: level, msg: {:string, _}, meta: %{mfa: {module, function, arity}} = meta})
+  # Restricted to the :elixir domain (Logger calls): on OTP < 27 or Elixir < 1.19
+  # the translator flattens OTP/SASL reports into string messages whose mfa points
+  # inside OTP (e.g. :supervisor.restart/2), and those keep their report text.
+  defp do_type(%{
+         level: level,
+         msg: {:string, _},
+         meta: %{mfa: {module, function, arity}, domain: [:elixir | _]} = meta
+       })
        when not is_map_key(meta, :__posthog_crash_reporter__),
        do: "Logger #{level} (#{Exception.format_mfa(module, function, arity)})"
 

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -25,7 +25,7 @@ defmodule PostHog.HandlerTest do
              properties: %{
                "$exception_list": [
                  %{
-                   type: "Hello World",
+                   type: "Logger info (" <> _,
                    value: "Hello World",
                    mechanism: %{handled: true, type: "generic"}
                  }
@@ -53,7 +53,7 @@ defmodule PostHog.HandlerTest do
                foo: "bar",
                "$exception_list": [
                  %{
-                   type: "Hello World",
+                   type: "Logger info (" <> _,
                    value: "Hello World",
                    mechanism: %{handled: true, type: "generic"}
                  }
@@ -75,7 +75,7 @@ defmodule PostHog.HandlerTest do
              properties: %{
                "$exception_list": [
                  %{
-                   type: "Hello World",
+                   type: "Logger info (PostHog.HandlerTest.log_plain_message/0)",
                    value: "Hello World",
                    stacktrace: %{
                      type: "raw",
@@ -106,6 +106,33 @@ defmodule PostHog.HandlerTest do
     expected_line = __ENV__.line + 1
     Logger.info("Hello World")
     expected_line
+  end
+
+  test "plain log message type groups by call site, not message content", %{
+    handler_ref: ref,
+    config: %{supervisor_name: supervisor_name}
+  } do
+    log_crawl_failure("https://a.example")
+    LoggerHandlerKit.Assert.assert_logged(ref)
+    log_crawl_failure("https://b.example")
+    LoggerHandlerKit.Assert.assert_logged(ref)
+
+    assert [
+             %{properties: %{"$exception_list": [exception_a]}},
+             %{properties: %{"$exception_list": [exception_b]}}
+           ] = all_captured(supervisor_name)
+
+    assert exception_a.type == "Logger error (PostHog.HandlerTest.log_crawl_failure/1)"
+    assert exception_b.type == exception_a.type
+
+    assert Enum.sort([exception_a.value, exception_b.value]) == [
+             "Failed to crawl https://a.example",
+             "Failed to crawl https://b.example"
+           ]
+  end
+
+  defp log_crawl_failure(url) do
+    Logger.error("Failed to crawl #{url}")
   end
 
   @tag config: [capture_level: :warning]
@@ -1544,7 +1571,7 @@ defmodule PostHog.HandlerTest do
                extra: "Foo",
                "$exception_list": [
                  %{
-                   type: "Error with metadata",
+                   type: "Logger error (" <> _,
                    value: "Error with metadata",
                    mechanism: %{handled: true}
                  }
@@ -1575,7 +1602,7 @@ defmodule PostHog.HandlerTest do
                  should: "work",
                  "$exception_list": [
                    %{
-                     type: "Error with metadata",
+                     type: "Logger error (" <> _,
                      value: "Error with metadata",
                      mechanism: %{handled: true}
                    }
@@ -1664,7 +1691,7 @@ defmodule PostHog.HandlerTest do
                foo: "bar",
                "$exception_list": [
                  %{
-                   type: "Error with metadata",
+                   type: "Logger error (" <> _,
                    value: "Error with metadata",
                    mechanism: %{handled: true, type: "generic"}
                  }

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -135,6 +135,33 @@ defmodule PostHog.HandlerTest do
     Logger.error("Failed to crawl #{url}")
   end
 
+  @tag handle_sasl_reports: true
+  test "translated OTP report strings keep their message-derived type", %{
+    handler_ref: ref,
+    config: %{supervisor_name: supervisor_name}
+  } do
+    # On OTP < 27 / Elixir < 1.19 the Logger translator flattens OTP/SASL reports
+    # into string messages whose mfa points inside OTP; those must not be
+    # re-typed to the (meaningless) OTP call site. Uses :logger.log/3 because the
+    # Elixir Logger API always prepends :elixir to the domain.
+    :logger.log(:error, "Child :task of Supervisor #PID<0.123.0> caused shutdown", %{
+      mfa: {:supervisor, :restart, 2},
+      domain: [:otp, :sasl]
+    })
+
+    LoggerHandlerKit.Assert.assert_logged(ref)
+
+    assert [event] = all_captured(supervisor_name)
+
+    assert %{
+             properties: %{
+               "$exception_list": [
+                 %{type: "Child :task of Supervisor #PID<0.123.0> caused shutdown"}
+               ]
+             }
+           } = event
+  end
+
   @tag config: [capture_level: :warning]
   test "ignores messages lower than capture_level", %{
     handler_ref: ref,


### PR DESCRIPTION
## :bulb: Motivation and Context

Exception events built from plain log messages (`capture_level` captures without a `crash_reason`) currently use the formatted message as the exception `type`. Log messages routinely interpolate dynamic values — ids, URLs, inspected terms — so every distinct message produces a distinct type. Error tracking fingerprints the exception type verbatim, which means a single `Logger.error("Failed to crawl #{url}")` call site creates a separate issue per event instead of one issue for the call site. In production data this makes captured-log exception events group dramatically worse than crash-derived ones: the large majority of such events end up with a unique fingerprint, and server-side masking can't help because the volatile parts are often plain words (URLs, entity names), not just numbers.

This PR keys the type on the logging call site instead: `Logger error (MyApp.Crawler.update_stats/2)`, derived from the `mfa` log metadata (the same metadata #152 uses for the synthetic stacktrace frame). The full message is still sent in `value`, so nothing is lost from the issue description or event detail. When `mfa` metadata is absent (e.g. `Logger.bare_log/3`), behavior is unchanged.

The crash-reporter entry of chained exceptions (a log message with an attached `crash_reason`) intentionally keeps its message-derived type: that entry names the issue, and for e.g. Bandit/Cowboy request crashes the banner (`** (RuntimeError) oops`) is a much better issue title than the logging call site inside the HTTP server would be. The marker that gates this never leaves the handler.

## :green_heart: How did you test it?

- Updated the handler tests that asserted message-derived types, plus a new regression test asserting that two differently-interpolated messages from the same call site produce the same type while keeping distinct values.
- `mix test` (316 passed), `mix format`, `mix credo --strict` (no new findings).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: investigated production grouping quality for elixir exception events, read the error tracking fingerprinting pipeline, and traced the unique-fingerprint explosion to message-derived exception types on stackless log captures (frames and chain order were ruled out as causes).
- Considered and rejected: masking volatile tokens server-side only (interpolated words survive masking), client-side `$exception_fingerprint` (bypasses server grouping rules), and applying the call-site type to crash-reporter chain entries (would regress issue titles for request crashes).
- Note for reviewers: this changes the emitted `type` for message captures, so existing issues for such events will re-key once — those groups are the ones currently splitting per event, so the practical cost is nil.
