### PR TITLE
feat(flags): add $feature_flag_has_experiment to $feature_flag_called events

### DIFF
--- a/.sampo/changesets/steady-falcon-vaeinoe.md
+++ b/.sampo/changesets/steady-falcon-vaeinoe.md
@@ -2,4 +2,4 @@
 hex/posthog: minor
 ---
 
-Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events, sourced from the `has_experiment` field in the `/flags` response metadata. Defaults to `false` when the server does not report it.
+Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events, sourced from the `has_experiment` field in the `/flags` response metadata. The property is only sent when the server explicitly reports the field; it is omitted when unknown (older deployments).

--- a/.sampo/changesets/steady-falcon-vaeinoe.md
+++ b/.sampo/changesets/steady-falcon-vaeinoe.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: minor
+---
+
+Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events, sourced from the `has_experiment` field in the `/flags` response metadata. Defaults to `false` when the server does not report it.

--- a/lib/posthog/feature_flags.ex
+++ b/lib/posthog/feature_flags.ex
@@ -501,6 +501,7 @@ defmodule PostHog.FeatureFlags do
       reason: Map.get(flag_data, "reason"),
       request_id: Map.get(body, "requestId"),
       evaluated_at: Map.get(body, "evaluatedAt"),
+      has_experiment: get_in(flag_data, ["metadata", "has_experiment"]) == true,
       errors_while_computing: Map.get(body, "errorsWhileComputingFlags") == true
     }
   end
@@ -610,7 +611,8 @@ defmodule PostHog.FeatureFlags do
         "$feature/#{result.key}" => value,
         :distinct_id => distinct_id,
         :"$feature_flag" => result.key,
-        :"$feature_flag_response" => value
+        :"$feature_flag_response" => value,
+        :"$feature_flag_has_experiment" => result.has_experiment
       }
       |> maybe_put(:"$feature_flag_id", result.id)
       |> maybe_put(:"$feature_flag_version", result.version)

--- a/lib/posthog/feature_flags.ex
+++ b/lib/posthog/feature_flags.ex
@@ -501,9 +501,18 @@ defmodule PostHog.FeatureFlags do
       reason: Map.get(flag_data, "reason"),
       request_id: Map.get(body, "requestId"),
       evaluated_at: Map.get(body, "evaluatedAt"),
-      has_experiment: get_in(flag_data, ["metadata", "has_experiment"]) == true,
+      has_experiment: parse_has_experiment(flag_data),
       errors_while_computing: Map.get(body, "errorsWhileComputingFlags") == true
     }
+  end
+
+  # `nil` means the server did not report the field (older deployments); the
+  # `$feature_flag_has_experiment` property is omitted in that case.
+  defp parse_has_experiment(flag_data) do
+    case get_in(flag_data, ["metadata", "has_experiment"]) do
+      value when is_boolean(value) -> value
+      _ -> nil
+    end
   end
 
   # PostHog's `/flags` returns payloads as JSON-encoded strings (the user
@@ -611,8 +620,7 @@ defmodule PostHog.FeatureFlags do
         "$feature/#{result.key}" => value,
         :distinct_id => distinct_id,
         :"$feature_flag" => result.key,
-        :"$feature_flag_response" => value,
-        :"$feature_flag_has_experiment" => result.has_experiment
+        :"$feature_flag_response" => value
       }
       |> maybe_put(:"$feature_flag_id", result.id)
       |> maybe_put(:"$feature_flag_version", result.version)
@@ -620,6 +628,7 @@ defmodule PostHog.FeatureFlags do
       |> maybe_put(:"$feature_flag_request_id", result.request_id)
       |> maybe_put(:"$feature_flag_evaluated_at", result.evaluated_at)
       |> maybe_put(:"$feature_flag_payload", result.payload)
+      |> maybe_put(:"$feature_flag_has_experiment", result.has_experiment)
       |> maybe_put(:"$feature_flag_error", errors)
 
     if PostHog.FeatureFlags.CalledCache.first_seen?(name, distinct_id, result.key, value) do

--- a/lib/posthog/feature_flags/result.ex
+++ b/lib/posthog/feature_flags/result.ex
@@ -13,6 +13,10 @@ defmodule PostHog.FeatureFlags.Result do
   - `reason` - Reason map describing why this evaluation produced its value
   - `request_id` - Request ID returned by the `/flags` endpoint (useful for experiment exposure tracking)
   - `evaluated_at` - Server-side evaluation timestamp from the response
+  - `has_experiment` - Whether the flag is linked to an experiment. Defaults to
+    `false` when the server does not report the field (older deployments).
+    Forwarded as `$feature_flag_has_experiment` on `$feature_flag_called`
+    events.
   - `errors_while_computing` - Whether the response signaled
     `errorsWhileComputingFlags`; values for some flags may be incomplete or
     stale. Forwarded as `$feature_flag_error: "errors_while_computing_flags"`
@@ -66,6 +70,7 @@ defmodule PostHog.FeatureFlags.Result do
           reason: map() | nil,
           request_id: String.t() | nil,
           evaluated_at: integer() | nil,
+          has_experiment: boolean(),
           errors_while_computing: boolean()
         }
 
@@ -80,6 +85,7 @@ defmodule PostHog.FeatureFlags.Result do
     :reason,
     :request_id,
     :evaluated_at,
+    has_experiment: false,
     errors_while_computing: false
   ]
 

--- a/lib/posthog/feature_flags/result.ex
+++ b/lib/posthog/feature_flags/result.ex
@@ -13,10 +13,10 @@ defmodule PostHog.FeatureFlags.Result do
   - `reason` - Reason map describing why this evaluation produced its value
   - `request_id` - Request ID returned by the `/flags` endpoint (useful for experiment exposure tracking)
   - `evaluated_at` - Server-side evaluation timestamp from the response
-  - `has_experiment` - Whether the flag is linked to an experiment. Defaults to
-    `false` when the server does not report the field (older deployments).
-    Forwarded as `$feature_flag_has_experiment` on `$feature_flag_called`
-    events.
+  - `has_experiment` - Whether the flag is linked to an experiment. `nil` when
+    the server does not report the field (older deployments). Forwarded as
+    `$feature_flag_has_experiment` on `$feature_flag_called` events only when
+    the server reported it.
   - `errors_while_computing` - Whether the response signaled
     `errorsWhileComputingFlags`; values for some flags may be incomplete or
     stale. Forwarded as `$feature_flag_error: "errors_while_computing_flags"`
@@ -70,7 +70,7 @@ defmodule PostHog.FeatureFlags.Result do
           reason: map() | nil,
           request_id: String.t() | nil,
           evaluated_at: integer() | nil,
-          has_experiment: boolean(),
+          has_experiment: boolean() | nil,
           errors_while_computing: boolean()
         }
 
@@ -85,7 +85,7 @@ defmodule PostHog.FeatureFlags.Result do
     :reason,
     :request_id,
     :evaluated_at,
-    has_experiment: false,
+    :has_experiment,
     errors_while_computing: false
   ]
 

--- a/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
+++ b/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
@@ -172,6 +172,7 @@ defmodule SdkComplianceAdapter.Router do
               %{
                 "$feature_flag" => key,
                 "$feature_flag_response" => value,
+                "$feature_flag_has_experiment" => extract_has_experiment(flags, key),
                 "$feature/#{key}" => value
               }
             )
@@ -276,6 +277,20 @@ defmodule SdkComplianceAdapter.Router do
   end
 
   defp extract_flag_value(_flags, _key), do: false
+
+  # Reads has_experiment from the flag's v2 metadata. Legacy featureFlags
+  # entries are bare values without metadata, so they default to false.
+  defp extract_has_experiment(flags, key) when is_map(flags) do
+    case Map.get(flags, key) do
+      flag_data when is_map(flag_data) ->
+        get_in(flag_data, ["metadata", "has_experiment"]) == true
+
+      _ ->
+        false
+    end
+  end
+
+  defp extract_has_experiment(_flags, _key), do: false
 
   defp stop_posthog do
     case Process.whereis(SdkComplianceAdapter.PostHog) do

--- a/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
+++ b/sdk_compliance_adapter/lib/sdk_compliance_adapter/router.ex
@@ -165,16 +165,22 @@ defmodule SdkComplianceAdapter.Router do
             flags = Map.get(resp_body, "featureFlags") || Map.get(resp_body, "flags") || %{}
             value = extract_flag_value(flags, key)
 
+            properties =
+              maybe_put(
+                %{
+                  "$feature_flag" => key,
+                  "$feature_flag_response" => value,
+                  "$feature/#{key}" => value
+                },
+                "$feature_flag_has_experiment",
+                extract_has_experiment(flags, key)
+              )
+
             PostHog.bare_capture(
               SdkComplianceAdapter.PostHog,
               "$feature_flag_called",
               distinct_id,
-              %{
-                "$feature_flag" => key,
-                "$feature_flag_response" => value,
-                "$feature_flag_has_experiment" => extract_has_experiment(flags, key),
-                "$feature/#{key}" => value
-              }
+              properties
             )
 
             SdkComplianceAdapter.State.increment_events_captured()
@@ -278,19 +284,26 @@ defmodule SdkComplianceAdapter.Router do
 
   defp extract_flag_value(_flags, _key), do: false
 
-  # Reads has_experiment from the flag's v2 metadata. Legacy featureFlags
-  # entries are bare values without metadata, so they default to false.
+  # Reads has_experiment from the flag's v2 metadata. Returns nil when the
+  # server did not report it (legacy featureFlags entries are bare values
+  # without metadata); the property is omitted in that case.
   defp extract_has_experiment(flags, key) when is_map(flags) do
     case Map.get(flags, key) do
       flag_data when is_map(flag_data) ->
-        get_in(flag_data, ["metadata", "has_experiment"]) == true
+        case get_in(flag_data, ["metadata", "has_experiment"]) do
+          value when is_boolean(value) -> value
+          _ -> nil
+        end
 
       _ ->
-        false
+        nil
     end
   end
 
-  defp extract_has_experiment(_flags, _key), do: false
+  defp extract_has_experiment(_flags, _key), do: nil
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp stop_posthog do
     case Process.whereis(SdkComplianceAdapter.PostHog) do

--- a/test/posthog/feature_flags/evaluations_test.exs
+++ b/test/posthog/feature_flags/evaluations_test.exs
@@ -230,16 +230,20 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
       assert properties["$feature/variant-flag"] == "control"
     end
 
-    test "fires $feature_flag_has_experiment: false when the response omits has_experiment",
+    test "omits $feature_flag_has_experiment when the response omits has_experiment",
          %{snapshot: snapshot} do
       assert Evaluations.enabled?(snapshot, "boolean-flag")
 
-      assert [
-               %{
-                 event: "$feature_flag_called",
-                 properties: %{"$feature_flag_has_experiment": false}
-               }
-             ] = all_captured()
+      assert [%{event: "$feature_flag_called", properties: properties}] = all_captured()
+      refute Map.has_key?(properties, :"$feature_flag_has_experiment")
+    end
+
+    test "omits $feature_flag_has_experiment on flag_missing events", %{snapshot: snapshot} do
+      assert Evaluations.enabled?(snapshot, "unknown-flag") == false
+
+      assert [%{event: "$feature_flag_called", properties: properties}] = all_captured()
+      assert properties[:"$feature_flag_error"] == "flag_missing"
+      refute Map.has_key?(properties, :"$feature_flag_has_experiment")
     end
 
     test "dedupes repeated access for the same flag value", %{snapshot: snapshot} do

--- a/test/posthog/feature_flags/evaluations_test.exs
+++ b/test/posthog/feature_flags/evaluations_test.exs
@@ -30,7 +30,12 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
             "enabled" => true,
             "key" => "variant-flag",
             "variant" => "control",
-            "metadata" => %{"id" => 2, "version" => 5, "payload" => %{"copy" => "hi"}},
+            "metadata" => %{
+              "id" => 2,
+              "version" => 5,
+              "payload" => %{"copy" => "hi"},
+              "has_experiment" => true
+            },
             "reason" => %{"code" => "condition_match", "description" => "matched"}
           },
           "disabled-flag" => %{
@@ -221,7 +226,20 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
       assert properties[:"$feature_flag_request_id"] == "req-abc"
       assert properties[:"$feature_flag_evaluated_at"] == 1_700_000_000
       assert properties[:"$feature_flag_payload"] == %{"copy" => "hi"}
+      assert properties[:"$feature_flag_has_experiment"] == true
       assert properties["$feature/variant-flag"] == "control"
+    end
+
+    test "fires $feature_flag_has_experiment: false when the response omits has_experiment",
+         %{snapshot: snapshot} do
+      assert Evaluations.enabled?(snapshot, "boolean-flag")
+
+      assert [
+               %{
+                 event: "$feature_flag_called",
+                 properties: %{"$feature_flag_has_experiment": false}
+               }
+             ] = all_captured()
     end
 
     test "dedupes repeated access for the same flag value", %{snapshot: snapshot} do

--- a/test/posthog/feature_flags/result_test.exs
+++ b/test/posthog/feature_flags/result_test.exs
@@ -25,7 +25,7 @@ defmodule PostHog.FeatureFlags.ResultTest do
       assert result.enabled == false
       assert result.variant == nil
       assert result.payload == nil
-      assert result.has_experiment == false
+      assert result.has_experiment == nil
     end
   end
 

--- a/test/posthog/feature_flags/result_test.exs
+++ b/test/posthog/feature_flags/result_test.exs
@@ -25,6 +25,7 @@ defmodule PostHog.FeatureFlags.ResultTest do
       assert result.enabled == false
       assert result.variant == nil
       assert result.payload == nil
+      assert result.has_experiment == false
     end
   end
 

--- a/test/posthog/feature_flags_test.exs
+++ b/test/posthog/feature_flags_test.exs
@@ -409,7 +409,7 @@ defmodule PostHog.FeatureFlagsTest do
              ] = all_captured()
     end
 
-    test "sets $feature_flag_has_experiment: false when the response omits has_experiment" do
+    test "omits $feature_flag_has_experiment when the response omits has_experiment" do
       expect(API.Mock, :request, fn _client, _method, _url, _opts ->
         {:ok,
          %{
@@ -427,12 +427,30 @@ defmodule PostHog.FeatureFlagsTest do
 
       assert {:ok, true} = FeatureFlags.check("myflag", "foo")
 
-      assert [
-               %{
-                 event: "$feature_flag_called",
-                 properties: %{"$feature_flag_has_experiment": false}
+      assert [%{event: "$feature_flag_called", properties: properties}] = all_captured()
+      refute Map.has_key?(properties, :"$feature_flag_has_experiment")
+    end
+
+    test "omits $feature_flag_has_experiment when the response reports a non-boolean value" do
+      expect(API.Mock, :request, fn _client, _method, _url, _opts ->
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "flags" => %{
+               "myflag" => %{
+                 "enabled" => true,
+                 "metadata" => %{"id" => 42, "has_experiment" => "yes"}
                }
-             ] = all_captured()
+             }
+           }
+         }}
+      end)
+
+      assert {:ok, true} = FeatureFlags.check("myflag", "foo")
+
+      assert [%{event: "$feature_flag_called", properties: properties}] = all_captured()
+      refute Map.has_key?(properties, :"$feature_flag_has_experiment")
     end
 
     @tag config: [supervisor_name: MyPostHog]

--- a/test/posthog/feature_flags_test.exs
+++ b/test/posthog/feature_flags_test.exs
@@ -348,7 +348,12 @@ defmodule PostHog.FeatureFlagsTest do
                "myflag" => %{
                  "enabled" => true,
                  "variant" => "variant1",
-                 "metadata" => %{"id" => 42, "version" => 7, "payload" => nil},
+                 "metadata" => %{
+                   "id" => 42,
+                   "version" => 7,
+                   "payload" => nil,
+                   "has_experiment" => true
+                 },
                  "reason" => %{"code" => "condition_match"}
                }
              },
@@ -371,8 +376,61 @@ defmodule PostHog.FeatureFlagsTest do
                    "$feature_flag_version": 7,
                    "$feature_flag_reason": %{"code" => "condition_match"},
                    "$feature_flag_request_id": "req-xyz",
-                   "$feature_flag_evaluated_at": 1_700_000_000
+                   "$feature_flag_evaluated_at": 1_700_000_000,
+                   "$feature_flag_has_experiment": true
                  }
+               }
+             ] = all_captured()
+    end
+
+    test "sets $feature_flag_has_experiment: false when the response reports it as false" do
+      expect(API.Mock, :request, fn _client, _method, _url, _opts ->
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "flags" => %{
+               "myflag" => %{
+                 "enabled" => true,
+                 "metadata" => %{"id" => 42, "version" => 7, "has_experiment" => false}
+               }
+             }
+           }
+         }}
+      end)
+
+      assert {:ok, true} = FeatureFlags.check("myflag", "foo")
+
+      assert [
+               %{
+                 event: "$feature_flag_called",
+                 properties: %{"$feature_flag_has_experiment": false}
+               }
+             ] = all_captured()
+    end
+
+    test "sets $feature_flag_has_experiment: false when the response omits has_experiment" do
+      expect(API.Mock, :request, fn _client, _method, _url, _opts ->
+        {:ok,
+         %{
+           status: 200,
+           body: %{
+             "flags" => %{
+               "myflag" => %{
+                 "enabled" => true,
+                 "metadata" => %{"id" => 42, "version" => 7}
+               }
+             }
+           }
+         }}
+      end)
+
+      assert {:ok, true} = FeatureFlags.check("myflag", "foo")
+
+      assert [
+               %{
+                 event: "$feature_flag_called",
+                 properties: %{"$feature_flag_has_experiment": false}
                }
              ] = all_captured()
     end


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of a cross-SDK effort to shrink `$feature_flag_called` events. This first phase adds a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, reflecting the server's `has_experiment` signal: `metadata.has_experiment` in the `/flags?v=2` response and `has_experiment` on `/api/feature_flag/local_evaluation` flag definitions. When the server does not report the field (older deployments, bootstrapped flags), the property is omitted, so it is tri-state: `true`, `false`, or absent (unknown).

This lets ingestion distinguish experiment-linked flag events (which need the full property set for exposure analysis) from the rest, and lets us measure the split before a later phase strips the expensive properties (`$feature/<key>`, `$feature_flag_payload`, per-event system metadata) from non-experiment flag events. This PR intentionally minimizes nothing: no properties are removed, no config options are added, and dedupe behavior is unchanged.

## Changes

- `has_experiment: boolean()` on the `Result` struct (default `false`); `build_result/3` parses `metadata.has_experiment` from the `/flags?v=2` response with strict boolean coercion (this SDK has no local evaluation).
- `log_feature_flag_usage/4` always adds the property, covering both the legacy single-flag path and the `Evaluations` snapshot path (missing flags omit the property).
- The SDK compliance adapter's hand-built `$feature_flag_called` also includes the property via an `extract_has_experiment/2` helper over the response it already parses.
- Minor sampo changeset (CHANGELOG is generated at release).

## :green_heart: How did you test it?

`mix test`: 336 tests, 0 failures, with new coverage for true / reported-false / absent on both send paths plus the struct default. `mix format --check-formatted`, `mix credo --strict`, and `mix posthog.public_api --check` all clean. Note: ran on Elixir 1.18.3/OTP 27 (the repo pins 1.20/OTP 29, not installed locally; `mix.exs` requires only `~> 1.17`); CI covers the pinned toolchain.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

