### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers:
+      - "PostHog/team-client-libraries"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    cooldown:
-      default-days: 7
+  - package-ecosystem: "mix"
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - "PostHog/team-client-libraries"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## :bulb: Motivation and Context

The repository did not have Dependabot coverage for all root SDK dependencies. This configures weekly updates for the root Mix dependencies and GitHub Actions, each with a seven-day cooldown. It intentionally relies on the repository's default CODEOWNERS rule to assign `@PostHog/team-client-libraries` rather than duplicating reviewers in Dependabot configuration.

## :green_heart: How did you test it?

Parsed `.github/dependabot.yml` with Ruby's YAML parser and asserted its exact structure, including ecosystem order, root directories, weekly schedules, seven-day cooldowns, and absence of extra options. Also ran `git diff --check`, `mix format --check-formatted`, and branch autoreview against `origin/main`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This change was implemented with the Pi worker agent and checked with Pi autoreview. The configuration is deliberately limited to the root Mix project and GitHub Actions; it does not add a separate compliance adapter entry, groups, labels, update limits, or explicit reviewers.
