### PR TITLE
ci: prevent Dependabot workflow failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      mix:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,6 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      codeql-action:
+      github-actions:
         patterns:
-          - "github/codeql-action*"
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/call-flags-project-board.yml
+++ b/.github/workflows/call-flags-project-board.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     call-flags-project:
-        uses: PostHog/.github/.github/workflows/flags-project-board.yml@d8b55d05dc5150f05c24542a6397ff3ecfbfb56d
+        uses: PostHog/.github/.github/workflows/flags-project-board.yml@95c20087fda2dc10fbbbcc3f1ef32b7bae779339
         with:
             pr_number: ${{ github.event.pull_request.number }}
             pr_node_id: ${{ github.event.pull_request.node_id }}


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot pull requests fail the Feature Flags project workflow because the pinned reusable workflow tries to read organization Actions secrets that GitHub withholds from Dependabot runs.

Dependabot also opens separate pull requests for each GitHub Action and Mix dependency. Separate CodeQL updates can temporarily give its `init` and `analyze` steps different versions, which causes CodeQL to fail.

This updates the Feature Flags workflow pin to a revision that skips Dependabot runs. It also groups GitHub Actions updates and Mix dependency updates into one pull request per ecosystem. This keeps related updates together and reduces the number of Dependabot pull requests.

## :green_heart: How did you test it?

- Parsed both changed files as YAML.
- Ran `git diff --check`.
- Confirmed the pinned reusable workflow checks `github.actor != 'dependabot[bot]'`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi and GitHub CLI were used to inspect failed workflow runs, compare the workflow configuration with other PostHog SDK repositories, and prepare this change. The existing fix in the shared `PostHog/.github` workflow was reused instead of exposing project-board credentials to Dependabot.
