### PR TITLE
fix: recompress request bodies on retry

### DIFF
--- a/.sampo/changesets/heroic-duchess-louhi.md
+++ b/.sampo/changesets/heroic-duchess-louhi.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Keep gzip-compressed request bodies valid across retries

--- a/lib/posthog/api/client.ex
+++ b/lib/posthog/api/client.ex
@@ -218,9 +218,19 @@ defmodule PostHog.API.Client do
   end
 
   defp compress_body_with_fallback(req) do
+    req =
+      if req.options[:compress_body] do
+        # Req re-encodes the body on retries but keeps headers from the prior attempt.
+        Req.Request.delete_header(req, "content-encoding")
+      else
+        req
+      end
+
     Req.Steps.compress_body(req)
   rescue
     _exception ->
-      Req.merge(req, compress_body: false)
+      req
+      |> Req.Request.delete_header("content-encoding")
+      |> Req.merge(compress_body: false)
   end
 end

--- a/test/posthog/api/client_test.exs
+++ b/test/posthog/api/client_test.exs
@@ -56,6 +56,30 @@ defmodule PostHog.API.ClientTest do
     assert_received {:request, {:ok, false}, []}
   end
 
+  test "request retries keep the compressed body reusable" do
+    parent = self()
+    {:ok, calls} = Agent.start_link(fn -> 0 end)
+
+    req =
+      Req.new(
+        base_url: "https://example.com",
+        retry: :transient,
+        retry_delay: fn _ -> 0 end,
+        max_retries: 1,
+        compress_body: true,
+        adapter: fn req ->
+          attempt = Agent.get_and_update(calls, fn calls -> {calls + 1, calls + 1} end)
+          send(parent, {:request, Req.Request.get_header(req, "content-encoding"), req.body})
+          {req, Req.Response.new(status: if(attempt == 1, do: 503, else: 200), body: %{})}
+        end
+      )
+
+    assert {:ok, %{status: 200}} = Client.request(req, :post, "/", json: %{event: "test"})
+    assert_received {:request, ["gzip"], first_body}
+    assert_received {:request, ["gzip"], second_body}
+    assert :zlib.gunzip(first_body) == :zlib.gunzip(second_body)
+  end
+
   test "request fallback does not catch adapter exceptions" do
     {:ok, calls} = Agent.start_link(fn -> 0 end)
 

--- a/test/posthog/api/client_test.exs
+++ b/test/posthog/api/client_test.exs
@@ -65,19 +65,21 @@ defmodule PostHog.API.ClientTest do
         base_url: "https://example.com",
         retry: :transient,
         retry_delay: fn _ -> 0 end,
-        max_retries: 1,
+        max_retries: 2,
         compress_body: true,
         adapter: fn req ->
           attempt = Agent.get_and_update(calls, fn calls -> {calls + 1, calls + 1} end)
           send(parent, {:request, Req.Request.get_header(req, "content-encoding"), req.body})
-          {req, Req.Response.new(status: if(attempt == 1, do: 503, else: 200), body: %{})}
+          {req, Req.Response.new(status: if(attempt <= 2, do: 503, else: 200), body: %{})}
         end
       )
 
     assert {:ok, %{status: 200}} = Client.request(req, :post, "/", json: %{event: "test"})
     assert_received {:request, ["gzip"], first_body}
     assert_received {:request, ["gzip"], second_body}
+    assert_received {:request, ["gzip"], third_body}
     assert :zlib.gunzip(first_body) == :zlib.gunzip(second_body)
+    assert :zlib.gunzip(second_body) == :zlib.gunzip(third_body)
   end
 
   test "request fallback does not catch adapter exceptions" do


### PR DESCRIPTION
## :bulb: Motivation and Context

Req re-encodes JSON request bodies when retrying, but retains the `content-encoding: gzip` header from the previous attempt. The retry body is therefore sent as plain JSON while marked as gzip. This caused retry requests to be unreadable and made six SDK compliance tests fail.

This change removes the stale content encoding before the compression step runs again. The retry is sent with a valid gzip body that preserves the original event UUID and timestamp. Compression fallback also removes the gzip header before sending an uncompressed body.

## :green_heart: How did you test it?

- `mix format --check-formatted`
- `mix test` - 331 passed, 18 excluded
- `mix credo --strict`
- `mix test test/posthog/api/client_test.exs` - 17 passed
- `docker compose up --build --abort-on-container-exit --exit-code-from test-harness` in `sdk_compliance_adapter` - 46/46 compliance tests passed

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to reproduce the compliance failures, inspect Req's retry pipeline, implement the fix, and run the project and Docker compliance suites. Autoreview checked the final committed diff and found no actionable issues. GitHub CLI was used to create this pull request.
