### PR TITLE
test: verify SDK timestamps use UTC

### DIFF
--- a/test/posthog_test.exs
+++ b/test/posthog_test.exs
@@ -189,6 +189,34 @@ defmodule PostHogTest do
       Jason.encode!(properties)
     end
 
+    test "generates a UTC timestamp without changing DateTime properties" do
+      local_datetime = %DateTime{
+        year: 2024,
+        month: 1,
+        day: 2,
+        hour: 3,
+        minute: 4,
+        second: 5,
+        microsecond: {678_000, 3},
+        time_zone: "Asia/Kathmandu",
+        zone_abbr: "+0545",
+        utc_offset: 20_700,
+        std_offset: 0
+      }
+
+      PostHog.bare_capture("timestamp test", "distinct_id", %{occurred_at: local_datetime})
+
+      assert [%{timestamp: timestamp, properties: %{occurred_at: ^local_datetime}} = event] =
+               all_captured()
+
+      assert String.ends_with?(timestamp, "Z")
+      assert {:ok, _datetime, 0} = DateTime.from_iso8601(timestamp)
+
+      wire_event = event |> Jason.encode!() |> Jason.decode!()
+      assert wire_event["timestamp"] == timestamp
+      assert wire_event["properties"]["occurred_at"] == "2024-01-02T03:04:05.678+05:45"
+    end
+
     test "uuid is valid v7" do
       PostHog.bare_capture("uuid test", "distinct_id")
 


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHog.bare_capture/3` adds an SDK-generated event timestamp in UTC. This test protects that behavior while confirming that a `DateTime` supplied as an event property keeps its original time zone offset.

The regression test captures an event with an `Asia/Kathmandu` property. It verifies that the generated event timestamp ends in `Z` and parses with a zero UTC offset. It also verifies that the captured property remains the original `DateTime` value and that JSON encoding produces `2024-01-02T03:04:05.678+05:45` for that property.

## :green_heart: How did you test it?

- `mix test test/posthog_test.exs` - 28 tests passed.
- `mix test` - 332 tests passed and 18 integration tests were excluded.
- `mix format --check-formatted test/posthog_test.exs`
- `git diff --check origin/main...HEAD`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

No changeset was added because this PR only adds regression coverage and does not release a product change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's worker agent preserved the existing test-only change, ran the repository tests, and completed an isolated autoreview. The task was kept to regression coverage with no production or release metadata changes. A shareable agent session link was not available in this environment.
