### PR TITLE
refactor: Share LLM response property construction

### DIFF
--- a/lib/posthog/integrations/llm_analytics/req.ex
+++ b/lib/posthog/integrations/llm_analytics/req.ex
@@ -306,15 +306,9 @@ defmodule PostHog.Integrations.LLMAnalytics.Req do
          "tools" => tools,
          "temperature" => temperature
        }) do
-    %{
-      "$ai_output_choices": output,
-      "$ai_input_tokens": input_tokens,
-      "$ai_output_tokens": output_tokens,
-      "$ai_model": model,
-      "$ai_tools": tools,
-      "$ai_temperature": temperature,
-      "$ai_is_error": false
-    }
+    model
+    |> successful_response_properties(output, input_tokens, output_tokens)
+    |> Map.merge(%{"$ai_tools": tools, "$ai_temperature": temperature})
   end
 
   # OpenAI Chat Completions
@@ -323,13 +317,7 @@ defmodule PostHog.Integrations.LLMAnalytics.Req do
          "choices" => output,
          "usage" => %{"completion_tokens" => output_tokens, "prompt_tokens" => input_tokens}
        }) do
-    %{
-      "$ai_output_choices": output,
-      "$ai_input_tokens": input_tokens,
-      "$ai_output_tokens": output_tokens,
-      "$ai_model": model,
-      "$ai_is_error": false
-    }
+    successful_response_properties(model, output, input_tokens, output_tokens)
   end
 
   # Gemini generateContent
@@ -345,13 +333,12 @@ defmodule PostHog.Integrations.LLMAnalytics.Req do
     reasoning_tokens = usage["thoughtsTokenCount"] || 0
     tool_use_tokens = usage["toolUsePromptTokenCount"] || 0
 
-    %{
-      "$ai_output_choices": output,
-      "$ai_input_tokens": input_tokens,
-      "$ai_output_tokens": candidates_tokens + reasoning_tokens + tool_use_tokens,
-      "$ai_model": model,
-      "$ai_is_error": false
-    }
+    successful_response_properties(
+      model,
+      output,
+      input_tokens,
+      candidates_tokens + reasoning_tokens + tool_use_tokens
+    )
   end
 
   # Anthropic Create Message
@@ -360,13 +347,7 @@ defmodule PostHog.Integrations.LLMAnalytics.Req do
          "content" => output,
          "usage" => %{"output_tokens" => output_tokens, "input_tokens" => input_tokens}
        }) do
-    %{
-      "$ai_output_choices": output,
-      "$ai_input_tokens": input_tokens,
-      "$ai_output_tokens": output_tokens,
-      "$ai_model": model,
-      "$ai_is_error": false
-    }
+    successful_response_properties(model, output, input_tokens, output_tokens)
   end
 
   defp response_properties(%{"error" => error}) do
@@ -377,6 +358,16 @@ defmodule PostHog.Integrations.LLMAnalytics.Req do
   end
 
   defp response_properties(_), do: %{}
+
+  defp successful_response_properties(model, output, input_tokens, output_tokens) do
+    %{
+      "$ai_output_choices": output,
+      "$ai_input_tokens": input_tokens,
+      "$ai_output_tokens": output_tokens,
+      "$ai_model": model,
+      "$ai_is_error": false
+    }
+  end
 
   defp atom_or_string_key(key) do
     fn :get, data, next ->


### PR DESCRIPTION
## :bulb: Motivation and Context

The OpenAI Responses, OpenAI Chat Completions, Gemini, and Anthropic parsers each built the same core LLM analytics response properties. Keeping those maps separate makes it easy for the provider implementations to drift when the shared properties change.

This refactor moves the shared successful-response map into one private function. Each provider still owns its response matching, token extraction, and additional properties.

## :green_heart: How did you test it?

- `mix test test/posthog/integrations/llm_analytics/req_test.exs`
- `mix test`
- `mix credo --strict`
- `mix format --check-formatted lib/posthog/integrations/llm_analytics/req.ex`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent and Slopo were used to identify and refactor the duplicated response-property maps. The refactor was limited to successful response map construction because provider-specific parsing remains clearer in each response clause. Pi autoreview found no actionable issues in the final commit.
