### PR TITLE
fix(flags): handle empty evaluation key scopes

### DIFF
--- a/.sampo/changesets/steadfast-iceseeker-mielikki.md
+++ b/.sampo/changesets/steadfast-iceseeker-mielikki.md
@@ -1,0 +1,5 @@
+---
+hex/posthog: patch
+---
+
+Return an empty feature flag snapshot without evaluation when feature flag keys are explicitly empty.

--- a/lib/posthog/feature_flags.ex
+++ b/lib/posthog/feature_flags.ex
@@ -97,6 +97,8 @@ defmodule PostHog.FeatureFlags do
   end
 
   @doc false
+  def evaluate_flags(nil), do: evaluate_flags(PostHog, nil)
+
   def evaluate_flags(distinct_id_or_body) when not is_atom(distinct_id_or_body),
     do: evaluate_flags(PostHog, distinct_id_or_body)
 
@@ -125,9 +127,11 @@ defmodule PostHog.FeatureFlags do
 
   Plus one snapshot-specific option:
 
-  - `:flag_keys` - list of flag keys. Forwarded to the request as
-    `flag_keys_to_evaluate` so the server returns only those flags. This
-    scopes the network response, distinct from
+  - `:flag_keys` - list of flag keys. A non-empty list is forwarded to the
+    request as `flag_keys_to_evaluate` so the server returns only those flags.
+    An empty list returns an empty snapshot without making a request. An
+    omitted or `nil` value evaluates all flags through the normal request path.
+    This scopes the network response, distinct from
     `PostHog.FeatureFlags.Evaluations.only/2` which filters an already-fetched
     snapshot in memory.
 
@@ -154,6 +158,9 @@ defmodule PostHog.FeatureFlags do
           {:ok, __MODULE__.Evaluations.t()} | {:error, Exception.t()}
   def evaluate_flags(name \\ PostHog, distinct_id_or_body \\ nil) do
     case body_for_flags(distinct_id_or_body) do
+      {:ok, %{distinct_id: distinct_id, flag_keys: []}} ->
+        {:ok, __MODULE__.Evaluations.new(name, distinct_id, %{"flags" => %{}})}
+
       {:ok, %{distinct_id: distinct_id} = body} ->
         body = translate_flag_keys(body)
 
@@ -232,6 +239,8 @@ defmodule PostHog.FeatureFlags do
   def set_in_context(name, %__MODULE__.Evaluations{} = snapshot) when is_atom(name) do
     PostHog.set_context(name, __MODULE__.Evaluations.event_properties(snapshot))
   end
+
+  defp translate_flag_keys(%{flag_keys: nil} = body), do: Map.delete(body, :flag_keys)
 
   defp translate_flag_keys(%{flag_keys: flag_keys} = body) when is_list(flag_keys) do
     body

--- a/test/posthog/feature_flags/evaluations_test.exs
+++ b/test/posthog/feature_flags/evaluations_test.exs
@@ -83,6 +83,27 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
       assert all_captured() == []
     end
 
+    test "returns an empty snapshot without a /flags request for an empty flag key list" do
+      deny(API.Mock, :request, 4)
+
+      assert {:ok, %Evaluations{distinct_id: "foo", flags: %{}} = snapshot} =
+               FeatureFlags.evaluate_flags(%{distinct_id: "foo", flag_keys: []})
+
+      assert Evaluations.keys(snapshot) == []
+    end
+
+    test "evaluates all flags through the normal request path when flag_keys is nil" do
+      expect(API.Mock, :request, 1, fn _client, :post, "/flags", opts ->
+        assert opts[:json] == %{distinct_id: "foo"}
+        {:ok, stub_flags_response()}
+      end)
+
+      assert {:ok, snapshot} =
+               FeatureFlags.evaluate_flags(%{distinct_id: "foo", flag_keys: nil})
+
+      assert Evaluations.keys(snapshot) == ["boolean-flag", "disabled-flag", "variant-flag"]
+    end
+
     test "translates :flag_keys into flag_keys_to_evaluate in the request body" do
       expect(API.Mock, :request, fn _client, :post, "/flags", opts ->
         assert opts[:json] == %{
@@ -125,7 +146,7 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
     end
 
     test "returns an empty snapshot when distinct_id cannot be resolved" do
-      assert {:ok, %Evaluations{distinct_id: "", flags: %{}}} =
+      assert {:ok, %Evaluations{supervisor_name: PostHog, distinct_id: "", flags: %{}}} =
                FeatureFlags.evaluate_flags(nil)
 
       assert all_captured() == []
@@ -599,7 +620,7 @@ defmodule PostHog.FeatureFlags.EvaluationsTest do
 
   describe "empty snapshot fallback" do
     test "evaluate_flags(nil) returns an empty snapshot, not an error" do
-      assert {:ok, %Evaluations{distinct_id: "", flags: %{}}} =
+      assert {:ok, %Evaluations{supervisor_name: PostHog, distinct_id: "", flags: %{}}} =
                FeatureFlags.evaluate_flags(nil)
     end
 


### PR DESCRIPTION
## :bulb: Motivation and Context

This implements the evaluation key scope behavior defined in [PostHog/sdk-specs#47](https://github.com/PostHog/sdk-specs/pull/47).

When `flag_keys` is omitted or `nil`, the SDK evaluates all flags through the normal `/flags` request. When `flag_keys` is an explicit empty list, the SDK returns an empty snapshot without making a request. When `flag_keys` is non-empty, the SDK sends those keys as `flag_keys_to_evaluate` so the server limits the evaluation.

This also makes `evaluate_flags(nil)` use the default `PostHog` supervisor and documents the three scope behaviors.

## :green_heart: How did you test it?

- `mix test test/posthog/feature_flags/evaluations_test.exs` - 50 tests passed.
- `mix test test/posthog/feature_flags/evaluations_test.exs:86` - the explicit empty-list regression passed independently.
- `mix test test/posthog/feature_flags/evaluations_test.exs:95` - the explicit `nil` regression passed independently.
- `mix test test/posthog/feature_flags/evaluations_test.exs:106` - the non-empty-list regression passed independently.
- `mix format --check-formatted` - passed with no formatting changes needed.
- `mix credo --strict` - checked 49 source files and found no issues.
- `git diff --check` - passed with no whitespace errors.
- `~/.pi/agent/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean with no accepted or actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

OpenAI Codex via Pi implemented and prepared this PR under human direction. The requested cross-SDK behavior and the repository's existing implementation patterns determined the change. No public session link is available.

