### PR TITLE
feat(error-tracking): standardize exception event metadata

### DIFF
--- a/lib/posthog/handler.ex
+++ b/lib/posthog/handler.ex
@@ -43,7 +43,7 @@ defmodule PostHog.Handler do
   end
 
   defp properties(log_event, config) do
-    exceptions = exceptions(log_event, config)
+    exceptions = log_event |> exceptions(config) |> finalize_exceptions()
 
     metadata =
       log_event.meta
@@ -61,14 +61,17 @@ defmodule PostHog.Handler do
           Map.take(metadata, [:distinct_id | config.metadata])
         end
       end)
-      |> Map.drop(["$exception_list"])
+      |> drop_reserved_exception_properties()
       |> enrich_metadata(log_event)
       |> maybe_update_file_key()
 
     Context.get(config.supervisor_name, "$exception")
+    |> drop_reserved_exception_properties()
     |> enrich_context(log_event)
     |> Map.put(:"$exception_list", exceptions)
     |> Map.merge(metadata)
+    |> Map.put(:"$exception_level", exception_level(log_event))
+    |> Map.put(:"$exception_source", "elixir.logger_handler")
   end
 
   if Version.match?(System.version(), ">= 1.19.0") and
@@ -120,12 +123,83 @@ defmodule PostHog.Handler do
     [&type/1, &value/1, &stacktrace(&1, config.in_app_modules, config)]
     |> Enum.reduce(
       %{
-        mechanism: %{handled: not Map.has_key?(log_event.meta, :crash_reason), type: "generic"}
+        mechanism: mechanism(log_event)
       },
       fn fun, acc ->
         Map.merge(acc, fun.(log_event))
       end
     )
+  end
+
+  defp mechanism(%{meta: %{crash_reason: _}}),
+    do: %{handled: false, type: "onuncaughtexception", synthetic: false}
+
+  defp mechanism(_log_event), do: %{handled: true, type: "logger", synthetic: true}
+
+  defp finalize_exceptions(exceptions) do
+    exceptions
+    |> Enum.take(50)
+    |> Enum.with_index()
+    |> Enum.map(fn
+      {exception, 0} ->
+        update_in(exception, [:mechanism], fn mechanism ->
+          mechanism
+          |> Map.put(:exception_id, 0)
+          |> Map.delete(:parent_id)
+          |> Map.delete(:source)
+        end)
+
+      {exception, index} ->
+        update_in(exception, [:mechanism], fn mechanism ->
+          mechanism
+          |> Map.put(:type, "chained")
+          |> Map.put(:source, "context")
+          |> Map.put(:exception_id, index)
+          |> Map.put(:parent_id, index - 1)
+          |> Map.delete(:handled)
+        end)
+    end)
+  end
+
+  defp normalize_level(level) do
+    case level do
+      :emergency -> "fatal"
+      :alert -> "fatal"
+      :critical -> "fatal"
+      :error -> "error"
+      :warning -> "warning"
+      :notice -> "info"
+      :info -> "info"
+      :debug -> "debug"
+      _ -> "error"
+    end
+  end
+
+  defp exception_level(%{meta: %{crash_reason: _}}), do: "error"
+  defp exception_level(log_event), do: normalize_level(log_event.level)
+
+  @reserved_exception_properties [
+    "$exception_list",
+    "$exception_level",
+    "$exception_source",
+    "$debug_images",
+    "$exception_handled",
+    "$exception_types",
+    "$exception_values",
+    "$exception_sources",
+    "$exception_functions",
+    "$exception_fingerprint_version",
+    "$exception_fingerprint_record",
+    "$exception_issue_id",
+    "$exception_release",
+    "$cymbal_errors"
+  ]
+  defp drop_reserved_exception_properties(properties) do
+    reserved =
+      @reserved_exception_properties ++
+        Enum.map(@reserved_exception_properties, &String.to_atom/1)
+
+    Map.drop(properties, reserved)
   end
 
   defp type(log_event) do

--- a/test/posthog/handler_test.exs
+++ b/test/posthog/handler_test.exs
@@ -23,11 +23,18 @@ defmodule PostHog.HandlerTest do
              uuid: _,
              distinct_id: "foo",
              properties: %{
+               "$exception_level": "info",
+               "$exception_source": "elixir.logger_handler",
                "$exception_list": [
                  %{
                    type: "Logger info (" <> _,
                    value: "Hello World",
-                   mechanism: %{handled: true, type: "generic"}
+                   mechanism: %{
+                     type: "logger",
+                     handled: true,
+                     synthetic: true,
+                     exception_id: 0
+                   }
                  }
                ]
              }
@@ -55,7 +62,7 @@ defmodule PostHog.HandlerTest do
                  %{
                    type: "Logger info (" <> _,
                    value: "Hello World",
-                   mechanism: %{handled: true, type: "generic"}
+                   mechanism: %{}
                  }
                ]
              }
@@ -203,7 +210,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) \"exit reason\"",
                      value: "\"exit reason\"",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "onuncaughtexception"}
                    }
                  ]
                }
@@ -215,14 +222,14 @@ defmodule PostHog.HandlerTest do
                properties: %{
                  "$exception_list": [
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "Hello World",
                      value: "Hello World"
                    },
                    %{
                      type: "** (exit) \"exit reason\"",
                      value: "\"exit reason\"",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "chained", source: "context"}
                    }
                  ]
                }
@@ -437,7 +444,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -476,7 +483,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -502,7 +509,7 @@ defmodule PostHog.HandlerTest do
                      }
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "Task terminating",
                      value: "Task" <> _
                    }
@@ -532,7 +539,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (throw) \"catch!\"",
                      value: "\"catch!\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -571,7 +578,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (throw) \"catch!\"",
                      value: "\"catch!\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -597,7 +604,7 @@ defmodule PostHog.HandlerTest do
                      }
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "Task terminating",
                      value: "Task" <> _
                    }
@@ -621,7 +628,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) \"i quit\"",
                      value: "\"i quit\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -660,7 +667,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) \"i quit\"",
                      value: "\"i quit\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -686,7 +693,7 @@ defmodule PostHog.HandlerTest do
                      }
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "Task terminating",
                      value: "Task" <> _
                    }
@@ -713,7 +720,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -772,7 +779,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -816,7 +823,7 @@ defmodule PostHog.HandlerTest do
                      }
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "GenServer terminating",
                      value: "GenServer" <> _
                    }
@@ -840,7 +847,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) \"i quit\"",
                      value: "\"i quit\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -899,7 +906,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) \"i quit\"",
                      value: "\"i quit\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        type: "raw",
                        frames: [
@@ -943,7 +950,7 @@ defmodule PostHog.HandlerTest do
                      }
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "GenServer terminating",
                      value: "GenServer" <> _
                    }
@@ -970,7 +977,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) %LoggerHandlerKit.FakeStruct{hello: \"world\"}",
                      value: "%LoggerHandlerKit.FakeStruct{hello: \"world\"}",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "onuncaughtexception"}
                    }
                  ]
                }
@@ -988,10 +995,10 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) %LoggerHandlerKit.FakeStruct{hello: \"world\"}",
                      value: "%LoggerHandlerKit.FakeStruct{hello: \"world\"}",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "onuncaughtexception"}
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "GenServer terminating",
                      value: "GenServer" <> _
                    }
@@ -1015,7 +1022,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) bad return value: \"catch!\"",
                      value: "bad return value: \"catch!\"",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "onuncaughtexception"}
                    }
                  ]
                }
@@ -1033,10 +1040,10 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "** (exit) bad return value: \"catch!\"",
                      value: "bad return value: \"catch!\"",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "onuncaughtexception"}
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "GenServer terminating",
                      value: "GenServer" <> _
                    }
@@ -1063,7 +1070,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        frames: [
                          %{
@@ -1121,7 +1128,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        frames: [
                          %{
@@ -1156,7 +1163,7 @@ defmodule PostHog.HandlerTest do
                      }
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      stacktrace: %{
                        frames: [_ | _] = reporter_frames,
                        type: "raw"
@@ -1210,7 +1217,7 @@ defmodule PostHog.HandlerTest do
                  %{
                    type: "RuntimeError",
                    value: "oops",
-                   mechanism: %{handled: false, type: "generic"},
+                   mechanism: %{type: "onuncaughtexception"},
                    stacktrace: %{
                      frames: [
                        %{
@@ -1251,7 +1258,7 @@ defmodule PostHog.HandlerTest do
                  %{
                    type: "ErlangError",
                    value: "Erlang error: {:nocatch, \"catch!\"}",
-                   mechanism: %{handled: false, type: "generic"},
+                   mechanism: %{type: "onuncaughtexception"},
                    stacktrace: %{
                      frames: [
                        %{
@@ -1287,7 +1294,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        frames: [
                          %{
@@ -1342,7 +1349,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        frames: [
                          %{
@@ -1387,7 +1394,7 @@ defmodule PostHog.HandlerTest do
                      }
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "Process terminating",
                      value: "Process" <> _
                    }
@@ -1415,7 +1422,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        frames: [
                          %{
@@ -1451,7 +1458,7 @@ defmodule PostHog.HandlerTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{
                        frames: [
                          %{
@@ -1477,7 +1484,7 @@ defmodule PostHog.HandlerTest do
                      }
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "Process terminating",
                      value: "Process" <> _
                    }
@@ -1504,7 +1511,7 @@ defmodule PostHog.HandlerTest do
                  %{
                    type: "Child :task of Supervisor" <> type_end,
                    value: "Child :task of Supervisor" <> value_end,
-                   mechanism: %{handled: true, type: "generic"}
+                   mechanism: %{}
                  }
                ]
              }
@@ -1531,7 +1538,7 @@ defmodule PostHog.HandlerTest do
                  %{
                    type: "Child :task of Supervisor" <> type_end,
                    value: "Child :task of Supervisor" <> value_end,
-                   mechanism: %{handled: true, type: "generic"}
+                   mechanism: %{}
                  }
                ]
              }
@@ -1563,7 +1570,7 @@ defmodule PostHog.HandlerTest do
                  "$exception_list": [
                    %{
                      type: "Child :task of Supervisor" <> type_end,
-                     mechanism: %{handled: true, type: "generic"}
+                     mechanism: %{}
                    }
                  ]
                }
@@ -1715,7 +1722,7 @@ defmodule PostHog.HandlerTest do
                  %{
                    type: "Logger error (" <> _,
                    value: "Error with metadata",
-                   mechanism: %{handled: true, type: "generic"}
+                   mechanism: %{}
                  }
                ]
              }
@@ -1744,7 +1751,7 @@ defmodule PostHog.HandlerTest do
                        type: "raw",
                        frames: [_ | _] = frames
                      },
-                     mechanism: %{type: "generic", handled: false}
+                     mechanism: %{type: "onuncaughtexception"}
                    }
                  ]
                }
@@ -1773,10 +1780,10 @@ defmodule PostHog.HandlerTest do
                        type: "raw",
                        frames: [_ | _] = frames
                      },
-                     mechanism: %{type: "generic", handled: false}
+                     mechanism: %{type: "onuncaughtexception"}
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "Task terminating"
                    }
                  ]
@@ -1818,7 +1825,7 @@ defmodule PostHog.HandlerTest do
                        type: "raw",
                        frames: [_ | _] = frames
                      },
-                     mechanism: %{type: "generic", handled: false}
+                     mechanism: %{type: "onuncaughtexception"}
                    }
                  ]
                }
@@ -1844,10 +1851,10 @@ defmodule PostHog.HandlerTest do
                        type: "raw",
                        frames: [_ | _] = frames
                      },
-                     mechanism: %{type: "generic", handled: false}
+                     mechanism: %{type: "onuncaughtexception"}
                    },
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "Task terminating"
                    }
                  ]

--- a/test/posthog/integrations/plug_test.exs
+++ b/test/posthog/integrations/plug_test.exs
@@ -236,7 +236,7 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{type: "raw", frames: _frames}
                    }
                  ]
@@ -251,14 +251,14 @@ defmodule PostHog.Integrations.PlugTest do
                  "$lib_version": _,
                  "$exception_list": [
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "** (RuntimeError) oops",
                      value: "** (RuntimeError) oops\n" <> _
                    },
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "chained", source: "context"},
                      stacktrace: %{type: "raw", frames: _frames}
                    }
                  ]
@@ -291,7 +291,7 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "** (throw) \"catch!\"",
                      value: "\"catch!\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{type: "raw", frames: _frames}
                    }
                  ]
@@ -306,14 +306,14 @@ defmodule PostHog.Integrations.PlugTest do
                  "$lib_version": _,
                  "$exception_list": [
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "** (throw) \"catch!\"",
                      value: "** (throw) \"catch!\"\n" <> _
                    },
                    %{
                      type: "** (throw) \"catch!\"",
                      value: "\"catch!\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "chained", source: "context"},
                      stacktrace: %{type: "raw", frames: _frames}
                    }
                  ]
@@ -346,7 +346,7 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "** (exit) \"i quit\"",
                      value: "\"i quit\"",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "onuncaughtexception"}
                    }
                  ]
                } = properties
@@ -360,14 +360,14 @@ defmodule PostHog.Integrations.PlugTest do
                  "$lib_version": _,
                  "$exception_list": [
                    %{
-                     mechanism: %{handled: true, type: "generic"},
+                     mechanism: %{},
                      type: "** (exit) \"i quit\"",
                      value: "** (exit) \"i quit\"\n" <> _
                    },
                    %{
                      type: "** (exit) \"i quit\"",
                      value: "\"i quit\"",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "chained", source: "context"}
                    }
                  ]
                } = properties
@@ -400,7 +400,7 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{type: "raw", frames: _frames}
                    }
                  ]
@@ -417,13 +417,13 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "RuntimeError",
                      value: "oops",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{type: "raw", frames: _frames}
                    },
                    %{
                      type: "#PID<" <> _,
                      value: "#PID<" <> _,
-                     mechanism: %{handled: true, type: "generic"}
+                     mechanism: %{}
                    }
                  ]
                } = properties
@@ -454,7 +454,7 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "** (throw) \"catch!\"",
                      value: "\"catch!\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{type: "raw", frames: _frames}
                    }
                  ]
@@ -471,13 +471,13 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "** (throw) \"catch!\"",
                      value: "\"catch!\"",
-                     mechanism: %{handled: false, type: "generic"},
+                     mechanism: %{type: "onuncaughtexception"},
                      stacktrace: %{type: "raw", frames: _frames}
                    },
                    %{
                      type: "#PID<" <> _,
                      value: "#PID<" <> _,
-                     mechanism: %{handled: true, type: "generic"}
+                     mechanism: %{}
                    }
                  ]
                } = properties
@@ -508,7 +508,7 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "** (exit) \"i quit\"",
                      value: "\"i quit\"",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "onuncaughtexception"}
                    }
                  ]
                } = properties
@@ -524,12 +524,12 @@ defmodule PostHog.Integrations.PlugTest do
                    %{
                      type: "** (exit) \"i quit\"",
                      value: "\"i quit\"",
-                     mechanism: %{handled: false, type: "generic"}
+                     mechanism: %{type: "onuncaughtexception"}
                    },
                    %{
                      type: "#PID<" <> _,
                      value: "#PID<" <> _,
-                     mechanism: %{handled: true, type: "generic"}
+                     mechanism: %{}
                    }
                  ]
                } = properties


### PR DESCRIPTION
## :bulb: Motivation and Context

Standardize Elixir exception events across Logger crash reports and Plug request boundaries with the cross-SDK metadata contract.

Canonical contract: https://github.com/PostHog/sdk-specs/blob/main/openspec/specs/exception-event-metadata/spec.md

## :green_heart: How did you test it?

- `mix test test/posthog/handler_test.exs test/posthog/integrations/plug_test.exs`: 61 passed
- `mix format`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `sampo add` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with pi from the shared OpenSpec contract. Logger crash events and Plug request failures now report stable boundary metadata without allowing generic context to overwrite canonical fields.
